### PR TITLE
Add drop() to Decompressor

### DIFF
--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -146,6 +146,12 @@ impl Decompressor {
     }
 }
 
+impl Drop for Decompressor {
+    fn drop(&mut self) {
+        unsafe { raw::tjDestroy(self.handle); }
+    }
+}
+
 /// Decompress a JPEG image.
 ///
 /// Returns a newly allocated image with the given pixel `format`. If you have specific


### PR DESCRIPTION
I used `Decompressor::new()` and observed a memory leak.
I have confirmed that this change has addressed the issue.