### PR TITLE
Fix build on windows

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -202,13 +202,27 @@ impl Subsamp {
     /// Get the width of the MCU block for this level of chrominance subsampling.
     #[doc(alias = "tjMCUWidth")]
     pub fn mcu_width(self) -> usize {
-        unsafe { raw::tjMCUWidth[self as usize] as usize }
+        self.mcu_size().0
     }
 
     /// Get the height of the MCU block for this level of chrominance subsampling.
     #[doc(alias = "tjMCUHeight")]
     pub fn mcu_height(self) -> usize {
-        unsafe { raw::tjMCUHeight[self as usize] as usize }
+        self.mcu_size().1
+    }
+
+    /// Get the size of the MCU block for this level of chrominance subsampling as (width, height).
+    #[doc(alias = "tjMCUWidth")]
+    #[doc(alias = "tjMCUHeight")]
+    pub fn mcu_size(self) -> (usize, usize) {
+        match self {
+            Subsamp::None => (8, 8),
+            Subsamp::Sub2x1 => (16, 8),
+            Subsamp::Sub2x2 => (16, 16),
+            Subsamp::Gray => (8, 8),
+            Subsamp::Sub1x2 => (8, 16),
+            Subsamp::Sub4x1 => (32, 8),
+        }
     }
 }
 

--- a/turbojpeg-sys/build.rs
+++ b/turbojpeg-sys/build.rs
@@ -155,9 +155,13 @@ fn build_vendor(link_kind: LinkKind) -> Result<Library> {
     let lib_path = dst_path.join("lib");
     let include_path = dst_path.join("include");
     println!("cargo:rustc-link-search=native={}", lib_path.display());
-    println!("cargo:rustc-link-lib={}=turbojpeg", match link_kind {
+    println!("cargo:rustc-link-lib={}=turbojpeg{}", match link_kind {
         LinkKind::Static | LinkKind::Default => "static",
         LinkKind::Dynamic => "dylib",
+    }, if env("CARGO_CFG_WINDOWS").is_some() && matches!(link_kind, LinkKind::Static | LinkKind::Default) {
+        "-static"
+    } else {
+        ""
     });
 
     Ok(Library {


### PR DESCRIPTION
This fixes two problems that seem to prevent the library from building on windows.

The first problem is the static version of library is ending up being called `libturbojpeg-static.lib` instead of just `libturbojpeg.lib`.

The second problem is that the tjMCUWidth and tjMCUHeight symbols are not found.  This appears to be due to them being declared as static within the turbojpeg header, but in that case I'm not sure why they would ever be linkable.  To work around it I added aliases that do get included/exported via an additional C file (so it should work independent of how bindgen is run).

I verified it works by running `cargo test --features image` successfully for both Linux and windows-msvc.  I was not able to verify windows-gnu works (cmake is picking up clang and failing for some reason, probably a local problem).  I was also not able to get it working while regenerating bindgen because I seem to get different types for the enums.  I also only attempted to make it work on windows with a static build of libturbojpeg.