### PR TITLE
Decode to yuv

### DIFF
--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -1,6 +1,5 @@
 use std::convert::TryInto as _;
-use crate::{Image, raw};
-use crate::image::YUVImage;
+use crate::{Image, YUVImage, raw};
 use crate::common::{PixelFormat, Subsamp, Colorspace, Result, Error, get_error};
 
 /// Decompresses JPEG data into raw pixels.
@@ -269,7 +268,12 @@ pub fn decompress_to_yuv(jpeg_data: &[u8]) -> Result<YUVImage<Vec<u8>>> {
     let mut decompressor = Decompressor::new()?;
     let header = decompressor.read_header(jpeg_data)?;
     let yuv_video_pad = 4;
-    let yuv_frame_size = match yuv_frame_size(header.width, yuv_video_pad, header.height, header.subsamp) {
+    let yuv_frame_size = match yuv_frame_size(
+        header.width,
+        yuv_video_pad,
+        header.height,
+        header.subsamp,
+    ) {
         Ok(size) => size,
         Err(e) => panic!("{}", e)
     };

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -182,7 +182,9 @@ impl Decompressor {
     /// ```
     #[doc(alias = "tjDecompressToYUV2")]
     pub fn decompress_to_yuv(&mut self, jpeg_data: &[u8], output: YuvImage<&mut [u8]>) -> Result<()> {
-        let YuvImage { pixels, width, pad, height } = output;
+        output.assert_valid(output.pixels.len());
+    
+        let YuvImage { pixels, width, pad, height , subsamp: _ } = output;
         let width = width.try_into().map_err(|_| Error::IntegerOverflow("width"))?;
         let pad = pad.try_into().map_err(|_| Error::IntegerOverflow("pad"))?;
         let height = height.try_into().map_err(|_| Error::IntegerOverflow("height"))?;
@@ -280,6 +282,7 @@ pub fn decompress_to_yuv(jpeg_data: &[u8]) -> Result<YuvImage<Vec<u8>>> {
         width: header.width,
         pad: yuv_video_pad,
         height: header.height,
+        subsamp: header.subsamp,
     };
     decompressor.decompress_to_yuv(jpeg_data, yuv_image.as_deref_mut())?;
 

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -171,6 +171,7 @@ impl Decompressor {
     ///     width: header.width,
     ///     pad: 4, // for video
     ///     height: header.height,
+    ///     subsamp: header.subsamp,
     /// };
     ///
     /// // decompress the JPEG into the image

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -1,5 +1,6 @@
 use std::convert::TryInto as _;
 use crate::{Image, raw};
+use crate::image::YUVImage;
 use crate::common::{PixelFormat, Subsamp, Colorspace, Result, Error, get_error};
 
 /// Decompresses JPEG data into raw pixels.
@@ -144,6 +145,65 @@ impl Decompressor {
             Err(unsafe { get_error(self.handle) })
         }
     }
+
+    /// Decompress a JPEG image in `jpeg_data` into `output` as YUV without changing color space.
+    ///
+    /// The decompressed image is stored in the pixel data of the given `output` image, which must
+    /// be fully initialized by the caller. Use [`read_header()`](Decompressor::read_header) to
+    /// determine the image size before calling this method.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// // read JPEG data from file
+    /// let jpeg_data = std::fs::read("examples/parrots.jpg")?;
+    ///
+    /// // initialize a decompressor
+    /// let mut decompressor = turbojpeg::Decompressor::new()?;
+    ///
+    /// // read the JPEG header
+    /// let header = decompressor.read_header(&jpeg_data)?;
+    /// // calculate yuv frame size
+    /// let yuv_frame_size = turbojpeg::yuv_frame_size(header.width, 4, header.height, header.subsamp);
+    ///
+    /// // initialize the image (YUVImage<Vec<u8>>)
+    /// let mut image = turbojpeg::YUVImage {
+    ///     pixels: vec![0; yuv_frame_size.unwrap()],
+    ///     width: header.width,
+    ///     pad: 4, // for video
+    ///     height: header.height,
+    /// };
+    ///
+    /// // decompress the JPEG into the image
+    /// // (we use as_deref_mut() to convert from &mut YUVImage<Vec<u8>> into YUVImage<&mut [u8]>)
+    /// decompressor.decompress_to_yuv(&jpeg_data, image.as_deref_mut())?;
+    /// assert_eq!(&image.pixels[0..4], &[116, 117, 118, 119]);
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[doc(alias = "tjDecompressToYUV2")]
+    pub fn decompress_to_yuv(&mut self, jpeg_data: &[u8], output: YUVImage<&mut [u8]>) -> Result<()> {
+        let YUVImage { pixels, width, pad, height } = output;
+        let width = width.try_into().map_err(|_| Error::IntegerOverflow("width"))?;
+        let pad = pad.try_into().map_err(|_| Error::IntegerOverflow("pad"))?;
+        let height = height.try_into().map_err(|_| Error::IntegerOverflow("height"))?;
+        let jpeg_data_len = jpeg_data.len().try_into()
+            .map_err(|_| Error::IntegerOverflow("jpeg_data.len()"))?;
+        let res = unsafe {
+            raw::tjDecompressToYUV2(
+                self.handle,
+                jpeg_data.as_ptr(), jpeg_data_len,
+                pixels.as_mut_ptr(), width, pad, height,
+                0,
+            )
+        };
+
+        if res == 0 {
+            Ok(())
+        } else {
+            Err(unsafe { get_error(self.handle) })
+        }
+    }
 }
 
 impl Drop for Decompressor {
@@ -186,6 +246,74 @@ pub fn decompress(jpeg_data: &[u8], format: PixelFormat) -> Result<Image<Vec<u8>
     decompressor.decompress(jpeg_data, image.as_deref_mut())?;
 
     Ok(image)
+}
+
+/// Decompress a JPEG image to YUV.
+///
+/// Returns a newly allocated yuv image
+///
+/// # Example
+///
+/// ```
+/// // read JPEG data from file
+/// let jpeg_data = std::fs::read("examples/parrots.jpg")?;
+///
+/// // decompress the JPEG into YUV image
+/// let image = turbojpeg::decompress_to_yuv(&jpeg_data)?;
+/// assert_eq!((image.width, image.height), (384, 256));
+/// assert_eq!(image.pixels.len(), 294912);
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn decompress_to_yuv(jpeg_data: &[u8]) -> Result<YUVImage<Vec<u8>>> {
+    let mut decompressor = Decompressor::new()?;
+    let header = decompressor.read_header(jpeg_data)?;
+    let yuv_video_pad = 4;
+    let yuv_frame_size = match yuv_frame_size(header.width, yuv_video_pad, header.height, header.subsamp) {
+        Ok(size) => size,
+        Err(e) => panic!("{}", e)
+    };
+
+    let mut yuv_image = YUVImage {
+        pixels: vec![0; yuv_frame_size],
+        width: header.width,
+        pad: yuv_video_pad,
+        height: header.height,
+    };
+    decompressor.decompress_to_yuv(jpeg_data, yuv_image.as_deref_mut())?;
+
+    Ok(yuv_image)
+}
+
+/// Determine size in bytes of a yuv image
+///
+/// Returns size in bytes of a yuv image
+/// 
+/// # Example
+///
+/// ```
+/// // read JPEG data from file
+/// let jpeg_data = std::fs::read("examples/parrots.jpg")?;
+///
+/// // read the JPEG header
+/// let header = turbojpeg::read_header(&jpeg_data)?;
+/// // get yuv frame size
+/// let yuv_video_pad = 4;
+/// let yuv_frame_size = turbojpeg::yuv_frame_size(header.width, yuv_video_pad, header.height, header.subsamp);
+/// assert_eq!(yuv_frame_size.unwrap(), 294912);
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn yuv_frame_size(width: usize, pad: usize, height: usize, subsamp: Subsamp) -> Result<usize> {
+    let width = width.try_into().map_err(|_| Error::IntegerOverflow("width"))?;
+    let pad = pad.try_into().map_err(|_| Error::IntegerOverflow("pad"))?;
+    let height = height.try_into().map_err(|_| Error::IntegerOverflow("height"))?;
+    let yuv_size = unsafe {
+        raw::tjBufSizeYUV2(width, pad, height, subsamp as libc::c_int)
+    };
+    let yuv_size = yuv_size.try_into().map_err(|_| Error::IntegerOverflow("yuv size"))?;
+
+    Ok(yuv_size)
 }
 
 /// Read the JPEG header without decompressing the image.

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -1,5 +1,5 @@
 use std::convert::TryInto as _;
-use crate::{Image, YUVImage, raw};
+use crate::{Image, YuvImage, raw};
 use crate::common::{PixelFormat, Subsamp, Colorspace, Result, Error, get_error};
 
 /// Decompresses JPEG data into raw pixels.
@@ -163,26 +163,26 @@ impl Decompressor {
     /// // read the JPEG header
     /// let header = decompressor.read_header(&jpeg_data)?;
     /// // calculate yuv frame size
-    /// let yuv_frame_size = turbojpeg::yuv_frame_size(header.width, 4, header.height, header.subsamp);
+    /// let yuv_pixels_len = turbojpeg::yuv_pixels_len(header.width, 4, header.height, header.subsamp);
     ///
-    /// // initialize the image (YUVImage<Vec<u8>>)
-    /// let mut image = turbojpeg::YUVImage {
-    ///     pixels: vec![0; yuv_frame_size.unwrap()],
+    /// // initialize the image (YuvImage<Vec<u8>>)
+    /// let mut image = turbojpeg::YuvImage {
+    ///     pixels: vec![0; yuv_pixels_len.unwrap()],
     ///     width: header.width,
     ///     pad: 4, // for video
     ///     height: header.height,
     /// };
     ///
     /// // decompress the JPEG into the image
-    /// // (we use as_deref_mut() to convert from &mut YUVImage<Vec<u8>> into YUVImage<&mut [u8]>)
+    /// // (we use as_deref_mut() to convert from &mut YuvImage<Vec<u8>> into YuvImage<&mut [u8]>)
     /// decompressor.decompress_to_yuv(&jpeg_data, image.as_deref_mut())?;
     /// assert_eq!(&image.pixels[0..4], &[116, 117, 118, 119]);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[doc(alias = "tjDecompressToYUV2")]
-    pub fn decompress_to_yuv(&mut self, jpeg_data: &[u8], output: YUVImage<&mut [u8]>) -> Result<()> {
-        let YUVImage { pixels, width, pad, height } = output;
+    pub fn decompress_to_yuv(&mut self, jpeg_data: &[u8], output: YuvImage<&mut [u8]>) -> Result<()> {
+        let YuvImage { pixels, width, pad, height } = output;
         let width = width.try_into().map_err(|_| Error::IntegerOverflow("width"))?;
         let pad = pad.try_into().map_err(|_| Error::IntegerOverflow("pad"))?;
         let height = height.try_into().map_err(|_| Error::IntegerOverflow("height"))?;
@@ -264,22 +264,19 @@ pub fn decompress(jpeg_data: &[u8], format: PixelFormat) -> Result<Image<Vec<u8>
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-pub fn decompress_to_yuv(jpeg_data: &[u8]) -> Result<YUVImage<Vec<u8>>> {
+pub fn decompress_to_yuv(jpeg_data: &[u8]) -> Result<YuvImage<Vec<u8>>> {
     let mut decompressor = Decompressor::new()?;
     let header = decompressor.read_header(jpeg_data)?;
     let yuv_video_pad = 4;
-    let yuv_frame_size = match yuv_frame_size(
+    let yuv_pixels_len = yuv_pixels_len(
         header.width,
         yuv_video_pad,
         header.height,
         header.subsamp,
-    ) {
-        Ok(size) => size,
-        Err(e) => panic!("{}", e)
-    };
+    )?;
 
-    let mut yuv_image = YUVImage {
-        pixels: vec![0; yuv_frame_size],
+    let mut yuv_image = YuvImage {
+        pixels: vec![0; yuv_pixels_len],
         width: header.width,
         pad: yuv_video_pad,
         height: header.height,
@@ -303,12 +300,12 @@ pub fn decompress_to_yuv(jpeg_data: &[u8]) -> Result<YUVImage<Vec<u8>>> {
 /// let header = turbojpeg::read_header(&jpeg_data)?;
 /// // get yuv frame size
 /// let yuv_video_pad = 4;
-/// let yuv_frame_size = turbojpeg::yuv_frame_size(header.width, yuv_video_pad, header.height, header.subsamp);
-/// assert_eq!(yuv_frame_size.unwrap(), 294912);
+/// let yuv_pixels_len = turbojpeg::yuv_pixels_len(header.width, yuv_video_pad, header.height, header.subsamp);
+/// assert_eq!(yuv_pixels_len.unwrap(), 294912);
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-pub fn yuv_frame_size(width: usize, pad: usize, height: usize, subsamp: Subsamp) -> Result<usize> {
+pub fn yuv_pixels_len(width: usize, pad: usize, height: usize, subsamp: Subsamp) -> Result<usize> {
     let width = width.try_into().map_err(|_| Error::IntegerOverflow("width"))?;
     let pad = pad.try_into().map_err(|_| Error::IntegerOverflow("pad"))?;
     let height = height.try_into().map_err(|_| Error::IntegerOverflow("height"))?;

--- a/src/image.rs
+++ b/src/image.rs
@@ -180,10 +180,11 @@ pub struct YuvImage<T> {
     pub pixels: T,
     /// Width of the image in pixels (number of columns).
     pub width: usize,
-    /// Pad the width of each line in each plane of the YUV image will be
-    /// padded to the nearest multiple of this number of bytes (must be a power of
-    /// 2.)  To generate images suitable for X Video, <tt>pad</tt> should be set to 4
-    pub pad: usize,
+    /// Align row alignment (in bytes) of the YUV image (must be a power of 2.) 
+    /// Setting this parameter to n will cause each row in each plane of the YUV 
+    /// image to be padded to the nearest multiple of n bytes (1 = unpadded.) 
+    /// To generate images suitable for X Video, align should be set to 4.
+    pub align: usize,
     /// Height of the image in pixels (number of rows).
     pub height: usize,
     /// The level of chrominance subsampling used in the YUV image.
@@ -198,7 +199,7 @@ impl<T> YuvImage<T> {
         YuvImage {
             pixels: self.pixels.deref(),
             width: self.width,
-            pad: self.pad,
+            align: self.align,
             height: self.height,
             subsamp: self.subsamp,
         }
@@ -211,17 +212,17 @@ impl<T> YuvImage<T> {
         YuvImage {
             pixels: self.pixels.deref_mut(),
             width: self.width,
-            pad: self.pad,
+            align: self.align,
             height: self.height,
             subsamp: self.subsamp,
         }
     }
 
     pub(crate) fn assert_valid(&self, pixels_len: usize) {
-        let YuvImage { pixels: _, width, pad, height, subsamp } = *self;
-        let min_yuv_pixels_len = yuv_pixels_len(width, pad, height, subsamp).unwrap();
+        let YuvImage { pixels: _, width, align, height, subsamp } = *self;
+        let min_yuv_pixels_len = yuv_pixels_len(width, align, height, subsamp).unwrap();
         assert!(min_yuv_pixels_len <= pixels_len,
-            "pixels length {} is too small for width {}, height {}, pad {} and subsamp {:?}",
-            pixels_len, width, height, pad, subsamp);
+            "pixels length {} is too small for width {}, height {}, align {} and subsamp {:?}",
+            pixels_len, width, height, align, subsamp);
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -186,6 +186,8 @@ pub struct YuvImage<T> {
     pub pad: usize,
     /// Height of the image in pixels (number of rows).
     pub height: usize,
+    /// The level of chrominance subsampling used in the YUV image.
+    pub subsamp: Subsamp,
 }
 
 impl<T> YuvImage<T> {
@@ -198,6 +200,7 @@ impl<T> YuvImage<T> {
             width: self.width,
             pad: self.pad,
             height: self.height,
+            subsamp: self.subsamp,
         }
     }
 
@@ -210,6 +213,15 @@ impl<T> YuvImage<T> {
             width: self.width,
             pad: self.pad,
             height: self.height,
+            subsamp: self.subsamp,
         }
+    }
+
+    pub(crate) fn assert_valid(&self, pixels_len: usize) {
+        let YuvImage { pixels: _, width, pad, height, subsamp } = *self;
+        let min_yuv_pixels_len = yuv_pixels_len(width, pad, height, subsamp).unwrap();
+        assert!(min_yuv_pixels_len <= pixels_len,
+            "pixels length {} is too small for width {}, height {}, pad {} and subsamp {:?}",
+            pixels_len, width, height, pad, subsamp);
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -8,7 +8,7 @@ use crate::common::PixelFormat;
 /// - `Image<&[u8]>`: immutable reference to image data (input image for compression by
 /// [`Compressor`][crate::Compressor])
 /// - `Image<&mut [u8]>`: mutable reference to image data (output image for decompression by
-/// [`Decompressor`][crate::Compressor]).
+/// [`Decompressor`][crate::Decompressor]).
 /// - `Image<Vec<u8>>`: owned image data (you can convert it to a reference using
 /// [`.as_deref()`][Image::as_deref] or [`.as_deref_mut()`][Image::as_deref_mut]).
 ///
@@ -169,14 +169,12 @@ impl Image<Vec<u8>> {
 
 /// A yuv image with pixels of type `T`.
 ///
-/// Three variants of this type are commonly used:
+/// Two variants of this type are commonly used:
 ///
-/// - `YUVImage<&[u8]>`: immutable reference to yuv image data (input image for compression by
-/// [`Compressor`][crate::Compressor])
 /// - `YUVImage<&mut [u8]>`: mutable reference to yuv image data (output image for decompression by
-/// [`Decompressor`][crate::Compressor]).
+/// [`Decompressor`][crate::Decompressor]).
 /// - `YUVImage<Vec<u8>>`: owned yuv image data (you can convert it to a reference using
-/// [`.as_deref()`][Image::as_deref] or [`.as_deref_mut()`][Image::as_deref_mut]).
+/// [`.as_deref()`][YUVImage::as_deref] or [`.as_deref_mut()`][YUVImage::as_deref_mut]).
 pub struct YUVImage<T> {
     /// Pixel data of the image (typically `&[u8]`, `&mut [u8]` or `Vec<u8>`).
     pub pixels: T,

--- a/src/image.rs
+++ b/src/image.rs
@@ -167,3 +167,51 @@ impl Image<Vec<u8>> {
     }
 }
 
+/// A yuv image with pixels of type `T`.
+///
+/// Three variants of this type are commonly used:
+///
+/// - `YUVImage<&[u8]>`: immutable reference to yuv image data (input image for compression by
+/// [`Compressor`][crate::Compressor])
+/// - `YUVImage<&mut [u8]>`: mutable reference to yuv image data (output image for decompression by
+/// [`Decompressor`][crate::Compressor]).
+/// - `YUVImage<Vec<u8>>`: owned yuv image data (you can convert it to a reference using
+/// [`.as_deref()`][Image::as_deref] or [`.as_deref_mut()`][Image::as_deref_mut]).
+pub struct YUVImage<T> {
+    /// Pixel data of the image (typically `&[u8]`, `&mut [u8]` or `Vec<u8>`).
+    pub pixels: T,
+    /// Width of the image in pixels (number of columns).
+    pub width: usize,
+    /// Pad the width of each line in each plane of the YUV image will be
+    /// padded to the nearest multiple of this number of bytes (must be a power of
+    /// 2.)  To generate images suitable for X Video, <tt>pad</tt> should be set to 4
+    pub pad: usize,
+    /// Height of the image in pixels (number of rows).
+    pub height: usize,
+}
+
+impl<T> YUVImage<T> {
+    /// Converts from `&YUVImage<T>` to `YUVImage<&T::Target>`.
+    ///
+    /// In particular, you can use this to get `YUVImage<&[u8]>` from `YUVImage<Vec<u8>>`.
+    pub fn as_deref(&self) -> YUVImage<&T::Target> where T: Deref {
+        YUVImage {
+            pixels: self.pixels.deref(),
+            width: self.width,
+            pad: self.pad,
+            height: self.height,
+        }
+    }
+
+    /// Converts from `&mut YUVImage<T>` to `YUVImage<&mut T::Target>`.
+    ///
+    /// In particular, you can use this to get `YUVImage<&mut [u8]>` from `YUVImage<Vec<u8>>`.
+    pub fn as_deref_mut(&mut self) -> YUVImage<&mut T::Target> where T: DerefMut {
+        YUVImage {
+            pixels: self.pixels.deref_mut(),
+            width: self.width,
+            pad: self.pad,
+            height: self.height,
+        }
+    }
+}

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,5 +1,5 @@
 use std::ops::{Deref, DerefMut};
-use crate::common::PixelFormat;
+use crate::{common::PixelFormat, Subsamp, yuv_pixels_len};
 
 /// An image with pixels of type `T`.
 ///
@@ -171,11 +171,11 @@ impl Image<Vec<u8>> {
 ///
 /// Two variants of this type are commonly used:
 ///
-/// - `YUVImage<&mut [u8]>`: mutable reference to yuv image data (output image for decompression by
+/// - `YuvImage<&mut [u8]>`: mutable reference to yuv image data (output image for decompression by
 /// [`Decompressor`][crate::Decompressor]).
-/// - `YUVImage<Vec<u8>>`: owned yuv image data (you can convert it to a reference using
-/// [`.as_deref()`][YUVImage::as_deref] or [`.as_deref_mut()`][YUVImage::as_deref_mut]).
-pub struct YUVImage<T> {
+/// - `YuvImage<Vec<u8>>`: owned yuv image data (you can convert it to a reference using
+/// [`.as_deref()`][YuvImage::as_deref] or [`.as_deref_mut()`][YuvImage::as_deref_mut]).
+pub struct YuvImage<T> {
     /// Pixel data of the image (typically `&[u8]`, `&mut [u8]` or `Vec<u8>`).
     pub pixels: T,
     /// Width of the image in pixels (number of columns).
@@ -188,12 +188,12 @@ pub struct YUVImage<T> {
     pub height: usize,
 }
 
-impl<T> YUVImage<T> {
-    /// Converts from `&YUVImage<T>` to `YUVImage<&T::Target>`.
+impl<T> YuvImage<T> {
+    /// Converts from `&YuvImage<T>` to `YuvImage<&T::Target>`.
     ///
-    /// In particular, you can use this to get `YUVImage<&[u8]>` from `YUVImage<Vec<u8>>`.
-    pub fn as_deref(&self) -> YUVImage<&T::Target> where T: Deref {
-        YUVImage {
+    /// In particular, you can use this to get `YuvImage<&[u8]>` from `YuvImage<Vec<u8>>`.
+    pub fn as_deref(&self) -> YuvImage<&T::Target> where T: Deref {
+        YuvImage {
             pixels: self.pixels.deref(),
             width: self.width,
             pad: self.pad,
@@ -201,11 +201,11 @@ impl<T> YUVImage<T> {
         }
     }
 
-    /// Converts from `&mut YUVImage<T>` to `YUVImage<&mut T::Target>`.
+    /// Converts from `&mut YuvImage<T>` to `YuvImage<&mut T::Target>`.
     ///
-    /// In particular, you can use this to get `YUVImage<&mut [u8]>` from `YUVImage<Vec<u8>>`.
-    pub fn as_deref_mut(&mut self) -> YUVImage<&mut T::Target> where T: DerefMut {
-        YUVImage {
+    /// In particular, you can use this to get `YuvImage<&mut [u8]>` from `YuvImage<Vec<u8>>`.
+    pub fn as_deref_mut(&mut self) -> YuvImage<&mut T::Target> where T: DerefMut {
+        YuvImage {
             pixels: self.pixels.deref_mut(),
             width: self.width,
             pad: self.pad,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,8 @@ mod transform;
 pub use self::buf::{OwnedBuf, OutputBuf};
 pub use self::common::{PixelFormat, Subsamp, Colorspace, Result, Error};
 pub use self::compress::{Compressor, compress, compressed_buf_len};
-pub use self::decompress::{Decompressor, DecompressHeader, decompress, read_header};
-pub use self::image::Image;
+pub use self::decompress::{Decompressor, DecompressHeader, decompress, read_header, decompress_to_yuv, yuv_frame_size};
+pub use self::image::{Image, YUVImage};
 pub use self::transform::{Transformer, Transform, TransformOp, TransformCrop, transform};
 
 #[cfg(feature = "image")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,8 @@ mod transform;
 pub use self::buf::{OwnedBuf, OutputBuf};
 pub use self::common::{PixelFormat, Subsamp, Colorspace, Result, Error};
 pub use self::compress::{Compressor, compress, compressed_buf_len};
-pub use self::decompress::{Decompressor, DecompressHeader, decompress, read_header, decompress_to_yuv, yuv_frame_size};
-pub use self::image::{Image, YUVImage};
+pub use self::decompress::{Decompressor, DecompressHeader, decompress, read_header, decompress_to_yuv, yuv_pixels_len};
+pub use self::image::{Image, YuvImage};
 pub use self::transform::{Transformer, Transform, TransformOp, TransformCrop, transform};
 
 #[cfg(feature = "image")]


### PR DESCRIPTION
This provides function calls to allow user to get planar YUV images from the jpeg their decoding. There's two functions: `decompressor.decompress_to_yuv`, and a helper `yuv_frame_size`. There's also a simpler `decompress_to_yuv` that returns a fresh yuv image buffer, similar to the `decompress` method.

These functions have passing rust doctest on them. Please let me know if I can alter any style/formatting/etc to be more in line with how this library does things.