### PR TITLE
change enum #[repr(u32)] to #[repr(i32)] for binding to  libjpeg-turbo latest version 3.0.1

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -131,7 +131,7 @@ impl PixelFormat {
 /// This is called "chrominance subsampling".
 #[doc(alias = "TJSAMP")]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(u32)]
+#[repr(i32)]
 pub enum Subsamp {
     /// No chrominance subsampling (4:4:4);
     ///
@@ -187,7 +187,7 @@ pub enum Subsamp {
 }
 
 impl Subsamp {
-    pub(crate) fn from_u32(subsamp: u32) -> Result<Self> {
+    pub(crate) fn from_i32(subsamp: i32) -> Result<Self> {
         Ok(match subsamp {
             raw::TJSAMP_TJSAMP_444 => Self::None,
             raw::TJSAMP_TJSAMP_422 => Self::Sub2x1,
@@ -286,7 +286,7 @@ impl Subsamp {
 /// JPEG colorspaces.
 #[doc(alias = "TJCS")]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(u32)]
+#[repr(i32)]
 pub enum Colorspace {
     /// RGB colorspace.
     ///
@@ -342,7 +342,7 @@ pub enum Colorspace {
 }
 
 impl Colorspace {
-    pub(crate) fn from_u32(colorspace: u32) -> Result<Colorspace> {
+    pub(crate) fn from_i32(colorspace: i32) -> Result<Colorspace> {
         Ok(match colorspace {
             raw::TJCS_TJCS_RGB => Colorspace::RGB,
             raw::TJCS_TJCS_YCbCr => Colorspace::YCbCr,
@@ -371,11 +371,11 @@ pub enum Error {
 
     /// TurboJPEG returned a chrominance subsampling variant that is not known by this crate.
     #[error("TurboJPEG returned unknown subsampling option: {0}")]
-    BadSubsamp(u32),
+    BadSubsamp(i32),
 
     /// TurboJPEG returned a colorspace variant that is not known by this crate.
     #[error("TurboJPEG returned unknown colorspace: {0}")]
-    BadColorspace(u32),
+    BadColorspace(i32),
 
     /// The given integer value overflowed when converted into type expected by TurboJPEG.
     #[error("integer value {0:?} overflowed")]

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -76,8 +76,8 @@ impl Decompressor {
         if res == 0 {
             let width = width.try_into().map_err(|_| Error::IntegerOverflow("width"))?;
             let height = height.try_into().map_err(|_| Error::IntegerOverflow("height"))?;
-            let subsamp = Subsamp::from_u32(subsamp as u32)?;
-            let colorspace = Colorspace::from_u32(colorspace as u32)?;
+            let subsamp = Subsamp::from_i32(subsamp as i32)?;
+            let colorspace = Colorspace::from_i32(colorspace as i32)?;
             Ok(DecompressHeader { width, height, subsamp, colorspace })
         } else {
             Err(unsafe { get_error(self.handle) })

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -104,7 +104,7 @@ pub struct Transform {
 /// Transform operation.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc(alias = "TJXOP")]
-#[repr(u32)]
+#[repr(i32)]
 pub enum TransformOp {
     /// No transformation (noop).
     #[doc(alias = "TJXOP_NONE")]

--- a/turbojpegEnv.bat
+++ b/turbojpegEnv.bat
@@ -1,0 +1,5 @@
+SET TURBOJPEG_STATIC=1
+SET TURBOJPEG_SOURCE=explicit
+SET TURBOJPEG_LIB_DIR=D:\\Programs\\libjpeg-turbo3010\\lib
+SET TURBOJPEG_INCLUDE_DIR=D:\\Programs\\libjpeg-turbo3010\\include
+SET TURBOJPEG_BINDING=bindgen


### PR DESCRIPTION
This fixing following compiling error while doing bindgen to libjpeg-turbo  3.0.1:
```
error[E0308]: mismatched types
   --> src\common.rs:141:12
    |
141 |     None = raw::TJSAMP_TJSAMP_444,
    |            ^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\common.rs:148:14
    |
148 |     Sub2x1 = raw::TJSAMP_TJSAMP_422,
    |              ^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\common.rs:155:14
    |
155 |     Sub2x2 = raw::TJSAMP_TJSAMP_420,
    |              ^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\common.rs:161:12
    |
161 |     Gray = raw::TJSAMP_TJSAMP_GRAY,
    |            ^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\common.rs:172:14
    |
172 |     Sub1x2 = raw::TJSAMP_TJSAMP_440,
    |              ^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\common.rs:186:14
    |
186 |     Sub4x1 = raw::TJSAMP_TJSAMP_411,
    |              ^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\common.rs:298:11
    |
298 |     RGB = raw::TJCS_TJCS_RGB,
    |           ^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\common.rs:314:13
    |
314 |     YCbCr = raw::TJCS_TJCS_YCbCr,
    |             ^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\common.rs:323:12
    |
323 |     Gray = raw::TJCS_TJCS_GRAY,
    |            ^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\common.rs:331:12
    |
331 |     CMYK = raw::TJCS_TJCS_CMYK,
    |            ^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\common.rs:341:12
    |
341 |     YCCK = raw::TJCS_TJCS_YCCK,
    |            ^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\transform.rs:111:12
    |
111 |     None = raw::TJXOP_TJXOP_NONE,
    |            ^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\transform.rs:118:13
    |
118 |     Hflip = raw::TJXOP_TJXOP_HFLIP,
    |             ^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\transform.rs:125:13
    |
125 |     Vflip = raw::TJXOP_TJXOP_VFLIP,
    |             ^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\transform.rs:131:17
    |
131 |     Transpose = raw::TJXOP_TJXOP_TRANSPOSE,
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\transform.rs:138:18
    |
138 |     Transverse = raw::TJXOP_TJXOP_TRANSVERSE,
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\transform.rs:145:13
    |
145 |     Rot90 = raw::TJXOP_TJXOP_ROT90,
    |             ^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\transform.rs:152:14
    |
152 |     Rot180 = raw::TJXOP_TJXOP_ROT180,
    |              ^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> src\transform.rs:158:14
    |
158 |     Rot270 = raw::TJXOP_TJXOP_ROT270,
    |              ^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `turbojpeg` (lib) due to 19 previous errors



```