### PR TITLE
Fix `x86_64-pc-windows-gnu` target compilation

### DIFF
--- a/turbojpeg-sys/build.rs
+++ b/turbojpeg-sys/build.rs
@@ -168,11 +168,14 @@ fn build_vendor(link_kind: LinkKind) -> Result<Library> {
 
     let lib_path = dst_path.join("lib");
     let include_path = dst_path.join("include");
+
+    let is_msvc = env("CARGO_CFG_TARGET_ENV").unwrap() == "msvc";
+
     println!("cargo:rustc-link-search=native={}", lib_path.display());
     println!("cargo:rustc-link-lib={}=turbojpeg{}", match link_kind {
         LinkKind::Static | LinkKind::Default => "static",
         LinkKind::Dynamic => "dylib",
-    }, if env("CARGO_CFG_WINDOWS").is_some() && matches!(link_kind, LinkKind::Static | LinkKind::Default) {
+    }, if is_msvc && matches!(link_kind, LinkKind::Static | LinkKind::Default) {
         "-static"
     } else {
         ""


### PR DESCRIPTION
In `build.rs` of `turbojpeg-sys` we should append `-static` to the linked library only for MSVC toolchain, not all Windows targets.

Fixes #21 