### PR TITLE
Change read_header API to allow RGB decompressing of unsupported subsampling

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -373,7 +373,7 @@ impl Colorspace {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// An error that can occur in TurboJPEG.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     /// TurboJPEG returned an error message.


### PR DESCRIPTION
With the existing API it seems impossible to read RGB image from a JPG that was encoded with unsupported subsampling.
Example file: 
![4x1](https://github.com/user-attachments/assets/c5ea1cf7-5039-46e1-9a7f-17f679d1f054)
