### PR TITLE
Add 1x4 chrominance subsampling (4:4:1) mapping

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -220,6 +220,7 @@ impl Subsamp {
             raw::TJSAMP_TJSAMP_GRAY => Self::Gray,
             raw::TJSAMP_TJSAMP_440 => Self::Sub1x2,
             raw::TJSAMP_TJSAMP_411 => Self::Sub4x1,
+            raw::TJSAMP_TJSAMP_441 => Self::Sub1x4,
             raw::TJSAMP_TJSAMP_UNKNOWN => Self::Unknown,
             other => return Err(Error::BadSubsamp(other)),
         })


### PR DESCRIPTION
Hello, it's me again. I guess I just have all the odd Jpegs. Here the one that wasn't supported:
![1x4](https://github.com/user-attachments/assets/bb758198-06e0-4368-9c19-94504b524be8)
