### PR TITLE
Hide the DESTDIR environment variable from cmake, otherwise the build fails

### DIFF
--- a/turbojpeg-sys/build.rs
+++ b/turbojpeg-sys/build.rs
@@ -143,6 +143,8 @@ fn build_vendor(link_kind: LinkKind) -> Result<Library> {
     let mut cmake = cmake::Config::new(source_path);
     cmake.configure_arg(format!("-DENABLE_SHARED={}", matches!(link_kind, LinkKind::Dynamic) as u32));
     cmake.configure_arg(format!("-DENABLE_STATIC={}", !matches!(link_kind, LinkKind::Dynamic) as u32));
+    // Ignore DESTDIR because it will install turbojpeg to the wrong location
+    cmake.env("DESTDIR", "");
     // On some 64 bit targets, the default libdir would be set to lib64.
     // Let's remain consistent across build targets and set the libdir ourselves,
     // instead of trying to figure out where to find the libs based on the target


### PR DESCRIPTION
I have `DESTDIR` set so that I can influence where my own application is installed when running "make install", but this affects the `cmake` build of `turbojpeg-sys` by installing files in the wrong place.

```
$ mkdir /dev/shm/DESTDIR
$ DESTDIR=/dev/shm/DESTDIR cargo build
   Compiling turbojpeg-sys v1.0.1 (/home/simon/src/rust-turbojpeg/turbojpeg-sys)
error: could not find native static library `turbojpeg`, perhaps an -L flag is missing?

error: could not compile `turbojpeg-sys` (lib) due to 1 previous error

$ find /dev/shm/DESTDIR/
/dev/shm/DESTDIR/
/dev/shm/DESTDIR/home
/dev/shm/DESTDIR/home/simon
/dev/shm/DESTDIR/home/simon/src
/dev/shm/DESTDIR/home/simon/src/rust-turbojpeg
/dev/shm/DESTDIR/home/simon/src/rust-turbojpeg/turbojpeg-sys
/dev/shm/DESTDIR/home/simon/src/rust-turbojpeg/turbojpeg-sys/target
/dev/shm/DESTDIR/home/simon/src/rust-turbojpeg/turbojpeg-sys/target/debug
/dev/shm/DESTDIR/home/simon/src/rust-turbojpeg/turbojpeg-sys/target/debug/build
/dev/shm/DESTDIR/home/simon/src/rust-turbojpeg/turbojpeg-sys/target/debug/build/turbojpeg-sys-3cb1ee0bda3dbcb0
```

Overriding `DESTDIR` to be `""` fixes the problem. This could be considered a bug in the [cmake-rs](https://github.com/rust-lang/cmake-rs) API? At the very least it needs to be possible to configure it to use a clean environment to ensure consistent results.