### PR TITLE
Bumb `libjpeg-turbo` version to 3.1.0

### DIFF
--- a/turbojpeg-sys/Cargo.toml
+++ b/turbojpeg-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbojpeg-sys"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 resolver = "2"
 


### PR DESCRIPTION
Building the crate fails for me, because `libjpeg-turbo` depends on a cmake version that has been deprecated

```
  │   --- stderr
  │   CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  │     Compatibility with CMake < 3.5 has been removed from CMake.
  │ 
  │     Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  │     to tell CMake that the project requires at least <min> but has been updated
  │     to work with policies introduced by <max> or earlier.
  │ 
  │     Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

This PR updates the `libjpeg-turbo` version from 3.0.1 to 3.1.0, which fixes the cmake error.