### PR TITLE
Encode from YUV planes

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1,5 +1,5 @@
 use std::convert::TryInto as _;
-use crate::{Image, YuvImage, raw};
+use crate::{Image, YuvImage, YuvPlanesImage, raw};
 use crate::buf::{OwnedBuf, OutputBuf};
 use crate::common::{Subsamp, Result, Error};
 use crate::handle::Handle;
@@ -293,6 +293,145 @@ impl Compressor {
         self.compress_yuv(image, &mut buf)?;
         Ok(buf.len())
     }
+
+    /// Compress separate YUV planes into JPEG.
+    ///
+    /// This function compresses separate Y, U (Cb), and V (Cr) image planes into 
+    /// a JPEG image. This is similar to [`compress_yuv()`][Self::compress_yuv], 
+    /// but takes separate YUV planes as input instead of interleaved YUV data.
+    ///
+    /// # Arguments
+    ///
+    /// * `yuv_planes` - YUV image with separate planes
+    /// * `output` - Output buffer for compressed JPEG data
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// // prepare YUV plane data
+    /// let width = 640;
+    /// let height = 480;
+    /// let y_plane = vec![128u8; width * height];
+    /// let u_plane = vec![128u8; (width/2) * (height/2)];
+    /// let v_plane = vec![128u8; (width/2) * (height/2)];
+    ///
+    /// let yuv_planes = turbojpeg::YuvPlanesImage {
+    ///     y_plane: &y_plane[..],
+    ///     u_plane: &u_plane[..],
+    ///     v_plane: &v_plane[..],
+    ///     width,
+    ///     height,
+    ///     y_stride: width,
+    ///     u_stride: width/2,
+    ///     v_stride: width/2,
+    ///     subsamp: turbojpeg::Subsamp::Sub2x2,
+    /// };
+    ///
+    /// // initialize the compressor
+    /// let mut compressor = turbojpeg::Compressor::new()?;
+    /// compressor.set_quality(90)?;
+    ///
+    /// // initialize the output buffer
+    /// let mut output_buf = turbojpeg::OutputBuf::new_owned();
+    ///
+    /// // compress YUV planes to JPEG
+    /// compressor.compress_yuv_planes(&yuv_planes, &mut output_buf)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[doc(alias = "tj3CompressFromYUVPlanes8")]
+    pub fn compress_yuv_planes(
+        &mut self,
+        yuv_planes: &YuvPlanesImage<&[u8]>,
+        output: &mut OutputBuf,
+    ) -> Result<()> {
+        let width = yuv_planes.width.try_into().map_err(|_| Error::IntegerOverflow("width"))?;
+        let height = yuv_planes.height.try_into().map_err(|_| Error::IntegerOverflow("height"))?;
+
+        let planes = [
+            yuv_planes.y_plane.as_ptr(),
+            yuv_planes.u_plane.as_ptr(),
+            yuv_planes.v_plane.as_ptr(),
+        ];
+
+        let strides = [
+            yuv_planes.y_stride.try_into().map_err(|_| Error::IntegerOverflow("y_stride"))?,
+            yuv_planes.u_stride.try_into().map_err(|_| Error::IntegerOverflow("u_stride"))?,
+            yuv_planes.v_stride.try_into().map_err(|_| Error::IntegerOverflow("v_stride"))?,
+        ];
+        
+        // Set subsampling from the YuvPlanesImage structure
+        self.set_subsamp(yuv_planes.subsamp)?;
+
+        self.handle.set(
+            raw::TJPARAM_TJPARAM_NOREALLOC,
+            if output.is_owned { 0 } else { 1 } as libc::c_int,
+        )?;
+
+        let mut output_len = output.len as raw::size_t;
+        let result = unsafe {
+            raw::tj3CompressFromYUVPlanes8(
+                self.handle.as_ptr(),
+                planes.as_ptr(),
+                width,
+                strides.as_ptr(),
+                height,
+                &mut output.ptr,
+                &mut output_len,
+            )
+        };
+        output.len = output_len as usize;
+
+        if result != 0 {
+            return Err(self.handle.get_error());
+        } else if output.ptr.is_null() {
+            output.len = 0;
+            return Err(Error::Null);
+        }
+
+        Ok(())
+    }
+
+    /// Compress separate YUV planes into an owned buffer.
+    ///
+    /// This method automatically allocates the memory for output and avoids needless copying.
+    pub fn compress_yuv_planes_to_owned(
+        &mut self,
+        yuv_planes: &YuvPlanesImage<&[u8]>,
+    ) -> Result<OwnedBuf> {
+        let mut buf = OutputBuf::new_owned();
+        self.compress_yuv_planes(yuv_planes, &mut buf)?;
+        Ok(buf.into_owned())
+    }
+
+    /// Compress separate YUV planes into a new `Vec<u8>`.
+    ///
+    /// This method copies the compressed data into a new `Vec`. If you would like to avoid the
+    /// extra allocation and copying, consider using
+    /// [`compress_yuv_planes_to_owned()`][Self::compress_yuv_planes_to_owned] instead.
+    pub fn compress_yuv_planes_to_vec(
+        &mut self,
+        yuv_planes: &YuvPlanesImage<&[u8]>,
+    ) -> Result<Vec<u8>> {
+        let mut buf = OutputBuf::new_owned();
+        self.compress_yuv_planes(yuv_planes, &mut buf)?;
+        Ok(buf.to_vec())
+    }
+
+    /// Compress separate YUV planes into the slice `output`.
+    ///
+    /// Returns the size of the compressed JPEG data. If the compressed image does not fit into
+    /// `dest`, this method returns an error. Use [`compressed_buf_len()`] to determine buffer size
+    /// that is guaranteed to be large enough for the compressed image.
+    pub fn compress_yuv_planes_to_slice(
+        &mut self,
+        yuv_planes: &YuvPlanesImage<&[u8]>,
+        output: &mut [u8],
+    ) -> Result<usize> {
+        let mut buf = OutputBuf::borrowed(output);
+        self.compress_yuv_planes(yuv_planes, &mut buf)?;
+        Ok(buf.len())
+    }
+
 
     /// Compute the maximum size of a compressed image.
     ///

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -499,6 +499,47 @@ pub fn compress_yuv(image: YuvImage<&[u8]>, quality: i32) -> Result<OwnedBuf> {
     compressor.compress_yuv_to_owned(image)
 }
 
+/// Compress separate YUV planes to JPEG.
+///
+/// Uses the given quality and returns the JPEG data in a buffer owned by TurboJPEG. If this
+/// function does not fit your needs, please see [`Compressor`].
+///
+/// # Example
+///
+/// ```
+/// // prepare YUV plane data
+/// let width = 640;
+/// let height = 480;
+/// let y_plane = vec![128u8; width * height];
+/// let u_plane = vec![128u8; (width/2) * (height/2)];
+/// let v_plane = vec![128u8; (width/2) * (height/2)];
+///
+/// let yuv_planes = turbojpeg::YuvPlanesImage {
+///     y_plane: &y_plane[..],
+///     u_plane: &u_plane[..],
+///     v_plane: &v_plane[..],
+///     width,
+///     height,
+///     y_stride: width,
+///     u_stride: width/2,
+///     v_stride: width/2,
+///     subsamp: turbojpeg::Subsamp::Sub2x2,
+/// };
+///
+/// // compress the YUV planes into JPEG with quality 90
+/// let jpeg_data = turbojpeg::compress_yuv_planes(&yuv_planes, 90)?;
+///
+/// // write the JPEG to disk
+/// std::fs::write(std::env::temp_dir().join("yuv_planes.jpg"), &jpeg_data)?;
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn compress_yuv_planes(yuv_planes: &YuvPlanesImage<&[u8]>, quality: i32) -> Result<OwnedBuf> {
+    let mut compressor = Compressor::new()?;
+    compressor.set_quality(quality)?;
+    compressor.compress_yuv_planes_to_owned(yuv_planes)
+}
+
 /// Compute the maximum size of a compressed image.
 ///
 /// This depends on image `width` and `height` and also on the chrominance subsampling method.

--- a/src/image_internal.rs
+++ b/src/image_internal.rs
@@ -2,6 +2,56 @@ use std::ops::{Deref, DerefMut};
 use crate::common::{PixelFormat, Subsamp};
 use crate::decompress::yuv_pixels_len;
 
+/// A YUV (YCbCr) image with separate planes.
+///
+/// This type stores an image in the JPEG color transform YCbCr (also called "YUV") with separate
+/// Y, U (Cb), and V (Cr) planes, as opposed to interleaved YUV data like [`YuvImage`].
+///
+/// Each plane has its own data and stride for maximum flexibility.
+///
+/// Two variants of this type are commonly used:
+///
+/// - `YuvPlanesImage<&[u8]>`: immutable reference to YUV plane data (input for compression)
+/// - `YuvPlanesImage<Vec<u8>>`: owned YUV plane data
+#[derive(Debug, Copy, Clone)]
+pub struct YuvPlanesImage<T> {
+    /// Y (luminance) plane data.
+    pub y_plane: T,
+    /// U (chrominance) plane data.
+    pub u_plane: T,
+    /// V (chrominance) plane data.
+    pub v_plane: T,
+    /// Width of the image in pixels (number of columns).
+    pub width: usize,
+    /// Height of the image in pixels (number of rows).
+    pub height: usize,
+    /// Y plane stride (bytes per row).
+    pub y_stride: usize,
+    /// U plane stride (bytes per row).
+    pub u_stride: usize,
+    /// V plane stride (bytes per row).
+    pub v_stride: usize,
+    /// The level of chrominance subsampling used in the YUV image.
+    pub subsamp: Subsamp,
+}
+
+impl<T> YuvPlanesImage<T> {
+    /// Converts from `&YuvPlanesImage<T>` to `YuvPlanesImage<&T::Target>`.
+    pub fn as_deref(&self) -> YuvPlanesImage<&T::Target> where T: Deref {
+        YuvPlanesImage {
+            y_plane: self.y_plane.deref(),
+            u_plane: self.u_plane.deref(),
+            v_plane: self.v_plane.deref(),
+            width: self.width,
+            height: self.height,
+            y_stride: self.y_stride,
+            u_stride: self.u_stride,
+            v_stride: self.v_stride,
+            subsamp: self.subsamp,
+        }
+    }
+}
+
 /// An image with pixels of type `T`.
 ///
 /// Three variants of this type are commonly used:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub use self::buf::{OwnedBuf, OutputBuf};
 pub use self::common::{PixelFormat, Subsamp, Colorspace, Result, Error};
 pub use self::compress::{Compressor, compress, compress_yuv, compressed_buf_len};
 pub use self::decompress::{Decompressor, DecompressHeader, ScalingFactor, decompress, read_header, decompress_to_yuv, yuv_pixels_len};
-pub use self::image_internal::{Image, YuvImage};
+pub use self::image_internal::{Image, YuvImage, YuvPlanesImage};
 pub use self::transform::{Transformer, Transform, TransformOp, TransformCrop, transform};
 
 #[cfg(feature = "image")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ mod image_internal;
 mod transform;
 pub use self::buf::{OwnedBuf, OutputBuf};
 pub use self::common::{PixelFormat, Subsamp, Colorspace, Result, Error};
-pub use self::compress::{Compressor, compress, compress_yuv, compressed_buf_len};
+pub use self::compress::{Compressor, compress, compress_yuv, compress_yuv_planes, compressed_buf_len};
 pub use self::decompress::{Decompressor, DecompressHeader, ScalingFactor, decompress, read_header, decompress_to_yuv, yuv_pixels_len};
 pub use self::image_internal::{Image, YuvImage, YuvPlanesImage};
 pub use self::transform::{Transformer, Transform, TransformOp, TransformCrop, transform};


### PR DESCRIPTION
Add support for compressing JPEG images from separate YUV planes.

This PR adds the `compress_yuv_planes()` function to the `Compressor`, which allows compressing separate YUV image planes into JPEG format. This is similar to the existing `compress_yuv()` function added in PR #18, but takes separate YUV planes as input instead of interleaved YUV data.