### PR TITLE
Export include directory to downstream crates

### DIFF
--- a/turbojpeg-sys/build.rs
+++ b/turbojpeg-sys/build.rs
@@ -173,6 +173,7 @@ fn build_vendor(link_kind: LinkKind) -> Result<Library> {
 
     let is_msvc = env("CARGO_CFG_TARGET_ENV").unwrap() == "msvc";
 
+    println!("cargo:include={}", include_path.display());
     println!("cargo:rustc-link-search=native={}", lib_path.display());
     println!("cargo:rustc-link-lib={}=turbojpeg{}", match link_kind {
         LinkKind::Static | LinkKind::Default => "static",


### PR DESCRIPTION
When building turbojpeg from source (vendored), the build script previously failed to output the `cargo:include=` directive. Because of this omission, Cargo never populated the `DEP_TURBOJPEG_INCLUDE` environment variable for downstream crates linking to `turbojpeg-sys`.

This adds the missing directive, allowing downstream C/C++ builds (like those using the `cc` crate) to properly locate and include `jpeglib.h`.