### PR TITLE
Add CI, address linter suggestions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,19 +21,22 @@ jobs:
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: ilammy/setup-nasm@v1
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
+      - run: rustup override set ${{ matrix.toolchain }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo build
 
   lint:
     runs-on: ubuntu-26.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: ilammy/setup-nasm@v1
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -46,7 +49,8 @@ jobs:
   test:
     runs-on: ubuntu-26.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: ilammy/setup-nasm@v1
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -57,7 +61,8 @@ jobs:
   examples:
     runs-on: ubuntu-26.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: ilammy/setup-nasm@v1
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,53 @@
+on: [push, pull_request]
+name: "CI"
+
+defaults:
+    run:
+        shell: bash
+
+jobs:
+    build:
+        strategy:
+            fail-fast: false
+            matrix:
+                toolchain: ["stable", "1.81", "beta", "nightly"]
+                os: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v5
+            - uses: dtolnay/rust-toolchain@master
+              with:
+                  toolchain: ${{ matrix.toolchain }}
+            - uses: Swatinem/rust-cache@v2
+            - run: cargo build
+
+    lint:
+        runs-on: ubuntu-26.04
+        steps:
+            - uses: actions/checkout@v5
+            - uses: dtolnay/rust-toolchain@stable
+              with:
+                  components: rustfmt, clippy
+            - uses: Swatinem/rust-cache@v1
+            - run: cargo clippy
+            - run: cargo fmt --check
+
+    test:
+        runs-on: ubuntu-26.04
+        steps:
+            - uses: actions/checkout@v5
+            - uses: dtolnay/rust-toolchain@stable
+            - uses: Swatinem/rust-cache@v2
+            - run: cargo test
+            - run: cargo test --doc
+
+    examples:
+        runs-on: ubuntu-26.04
+        steps:
+            - uses: actions/checkout@v5
+            - uses: dtolnay/rust-toolchain@stable
+            - uses: Swatinem/rust-cache@v2
+            - run: cargo run --example compressor
+            - run: cargo run --example decompressor
+            - run: cargo run --example downscale
+            - run: cargo run --example image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,9 +39,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
+      # - uses: dtolnay/rust-toolchain@stable
+      #   with:
+      #     components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v1
       - run: cargo clippy
       - run: cargo fmt --check
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
+      # - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
       - run: cargo test --doc
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
+      # - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo run --example compressor
       - run: cargo run --example decompressor

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,9 +39,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      # - uses: dtolnay/rust-toolchain@stable
-      #   with:
-      #     components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v1
       - run: cargo clippy
       - run: cargo fmt --check
@@ -53,7 +50,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      # - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
       - run: cargo test --doc
@@ -65,9 +61,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      # - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo run --example compressor
       - run: cargo run --example decompressor
       - run: cargo run --example downscale
-      - run: cargo run --example image
+      - run: cargo run --example --features image image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,6 @@ jobs:
           submodules: recursive
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
-      - run: cargo test --doc
 
   examples:
     runs-on: ubuntu-26.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
+          # - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: ilammy/setup-nasm@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,4 +65,4 @@ jobs:
       - run: cargo run --example compressor
       - run: cargo run --example decompressor
       - run: cargo run --example downscale
-      - run: cargo run --example --features image image
+      - run: cargo run --example image --features image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,52 +2,67 @@ on: [push, pull_request]
 name: "CI"
 
 defaults:
-    run:
-        shell: bash
+  run:
+    shell: bash
 
 jobs:
-    build:
-        strategy:
-            fail-fast: false
-            matrix:
-                toolchain: ["stable", "1.81", "beta", "nightly"]
-                os: [ubuntu-latest, macos-latest, windows-latest]
-        runs-on: ${{ matrix.os }}
-        steps:
-            - uses: actions/checkout@v5
-            - uses: dtolnay/rust-toolchain@master
-              with:
-                  toolchain: ${{ matrix.toolchain }}
-            - uses: Swatinem/rust-cache@v2
-            - run: cargo build
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - "1.81"
+          - "stable"
+          - "beta"
+          - "nightly"
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build
 
-    lint:
-        runs-on: ubuntu-26.04
-        steps:
-            - uses: actions/checkout@v5
-            - uses: dtolnay/rust-toolchain@stable
-              with:
-                  components: rustfmt, clippy
-            - uses: Swatinem/rust-cache@v1
-            - run: cargo clippy
-            - run: cargo fmt --check
+  lint:
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v1
+      - run: cargo clippy
+      - run: cargo fmt --check
 
-    test:
-        runs-on: ubuntu-26.04
-        steps:
-            - uses: actions/checkout@v5
-            - uses: dtolnay/rust-toolchain@stable
-            - uses: Swatinem/rust-cache@v2
-            - run: cargo test
-            - run: cargo test --doc
+  test:
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test
+      - run: cargo test --doc
 
-    examples:
-        runs-on: ubuntu-26.04
-        steps:
-            - uses: actions/checkout@v5
-            - uses: dtolnay/rust-toolchain@stable
-            - uses: Swatinem/rust-cache@v2
-            - run: cargo run --example compressor
-            - run: cargo run --example decompressor
-            - run: cargo run --example downscale
-            - run: cargo run --example image
+  examples:
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo run --example compressor
+      - run: cargo run --example decompressor
+      - run: cargo run --example downscale
+      - run: cargo run --example image

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .*.swp
 Session.vim
 *~
+image.jpg
+downscaled.jpg

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ README][sys-readme] for details.
 
 ## Contributing
 
+This repository contains a git submodule (`./turbojpeg-sys/libjpeg-turbo/`);
+be sure to clone it with `--recurse-submodules`.
+
 All contributions are welcome! Please contact me (@honzasp) or open a pull
 request. The main areas for improvement are:
 

--- a/examples/cjpeg.rs
+++ b/examples/cjpeg.rs
@@ -1,6 +1,6 @@
-use std::fs;
-use anyhow::{Result, Context as _};
+use anyhow::{Context as _, Result};
 use clap::clap_app;
+use std::fs;
 
 use turbojpeg::{Compressor, Image, PixelFormat};
 
@@ -30,7 +30,9 @@ fn main() -> Result<()> {
     let mut compressor = Compressor::new()?;
 
     if let Some(quality) = args.value_of("QUALITY") {
-        let quality = quality.parse().context("could not parse value of --quality")?;
+        let quality = quality
+            .parse()
+            .context("could not parse value of --quality")?;
         compressor.set_quality(quality)?;
     }
 

--- a/examples/compressor.rs
+++ b/examples/compressor.rs
@@ -5,14 +5,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (width, height) = (768, 512);
     let mut image = Image {
         pixels: vec![0; 3 * width * height],
-        width: width,
+        width,
         pitch: 3 * width, // there is no padding between rows
-        height: height,
+        height,
         format: PixelFormat::RGB,
     };
 
     // generate the pixel values
     for y in 0..height {
+        #[allow(clippy::identity_op)]
         for x in 0..width {
             let r = if (x/32 + y/32) % 2 == 0 { 0 } else { 255 };
             let g = 255 - (x * 255 / width) as u8;

--- a/examples/compressor.rs
+++ b/examples/compressor.rs
@@ -15,12 +15,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for y in 0..height {
         #[allow(clippy::identity_op)]
         for x in 0..width {
-            let r = if (x/32 + y/32) % 2 == 0 { 0 } else { 255 };
+            let r = if (x / 32 + y / 32) % 2 == 0 { 0 } else { 255 };
             let g = 255 - (x * 255 / width) as u8;
             let b = (y * 255 / height) as u8;
-            image.pixels[3*width*y + 3*x + 0] = r;
-            image.pixels[3*width*y + 3*x + 1] = g;
-            image.pixels[3*width*y + 3*x + 2] = b;
+            image.pixels[3 * width * y + 3 * x + 0] = r;
+            image.pixels[3 * width * y + 3 * x + 1] = g;
+            image.pixels[3 * width * y + 3 * x + 2] = b;
         }
     }
 
@@ -33,4 +33,3 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     std::fs::write("image.jpg", jpeg_data)?;
     Ok(())
 }
-

--- a/examples/decompressor.rs
+++ b/examples/decompressor.rs
@@ -14,13 +14,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // prepare the destination image
     let mut image = Image {
         pixels: vec![0; 3 * width * height],
-        width: width,
+        width,
         pitch: 3 * width, // we use no padding between rows
-        height: height,
+        height,
         format: PixelFormat::RGB,
     };
 
-    // decompress the JPEG data 
+    // decompress the JPEG data
     decompressor.decompress(&jpeg_data, image.as_deref_mut())?;
 
     // use the raw pixel data

--- a/examples/djpeg.rs
+++ b/examples/djpeg.rs
@@ -1,6 +1,6 @@
-use std::fs;
-use anyhow::{Result, Context as _};
+use anyhow::{Context as _, Result};
 use clap::clap_app;
+use std::fs;
 
 use turbojpeg::{Decompressor, Image, PixelFormat};
 
@@ -10,18 +10,18 @@ fn main() -> Result<()> {
         (@arg INPUT: <input> "Input JPEG file")
         (@arg OUTPUT: <output> "Output image file")
         (@arg SCALE: -s --scale [scale] "Apply a scaling factor (such as 7/8)")
-    ).get_matches();
+    )
+    .get_matches();
 
     let image_jpeg = fs::read(args.value_of("INPUT").unwrap())?;
 
     let scaling = match args.value_of("SCALE") {
         Some(scale) => {
-            let (num, denom) = scale.split_once('/')
-                .context("Wrong syntax of scale")?;
+            let (num, denom) = scale.split_once('/').context("Wrong syntax of scale")?;
             let num = num.parse()?;
             let denom = denom.parse()?;
             turbojpeg::ScalingFactor::new(num, denom)
-        },
+        }
         None => turbojpeg::ScalingFactor::ONE,
     };
 
@@ -39,13 +39,16 @@ fn main() -> Result<()> {
     assert_eq!(strides.1, 3);
     assert_eq!(extents.0, 3);
 
-    decompressor.decompress(&image_jpeg, Image {
-        pixels: image_flat.as_mut_slice(),
-        width: extents.1,
-        pitch: strides.2,
-        height: extents.2,
-        format: PixelFormat::RGB,
-    })?;
+    decompressor.decompress(
+        &image_jpeg,
+        Image {
+            pixels: image_flat.as_mut_slice(),
+            width: extents.1,
+            pitch: strides.2,
+            height: extents.2,
+            format: PixelFormat::RGB,
+        },
+    )?;
 
     image.save(args.value_of("OUTPUT").unwrap())?;
     Ok(())

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -18,8 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(image_1.width(), image_2.width());
     assert_eq!(image_1.height(), image_2.height());
     let error_sum = image_1.pixels().zip(image_2.pixels())
-        .map(|(pix_1, pix_2)| (0..3).map(move |i| pix_1[i] as i64 - pix_2[i] as i64))
-        .flatten()
+        .flat_map(|(pix_1, pix_2)| (0..3).map(move |i| pix_1[i] as i64 - pix_2[i] as i64))
         .map(|diff| diff * diff)
         .sum::<i64>();
     let error_mean = error_sum as f64 / (image_1.width() * image_1.height()) as f64;

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -2,7 +2,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // create an image
     let (width, height) = (400, 300);
     let image_1 = image::RgbImage::from_fn(width, height, |x, y| {
-        let r = if (x/32 + y/32) % 2 == 0 { 0 } else { 255 };
+        let r = if (x / 32 + y / 32) % 2 == 0 { 0 } else { 255 };
         let g = 255 - (x * 255 / width) as u8;
         let b = (y * 255 / height) as u8;
         image::Rgb([r, g, b])
@@ -17,7 +17,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(image_1.width(), image_2.width());
     assert_eq!(image_1.height(), image_2.height());
-    let error_sum = image_1.pixels().zip(image_2.pixels())
+    let error_sum = image_1
+        .pixels()
+        .zip(image_2.pixels())
         .flat_map(|(pix_1, pix_2)| (0..3).map(move |i| pix_1[i] as i64 - pix_2[i] as i64))
         .map(|diff| diff * diff)
         .sum::<i64>();

--- a/examples/jpegtran.rs
+++ b/examples/jpegtran.rs
@@ -1,6 +1,6 @@
-use std::fs;
-use anyhow::{Result, Context as _, bail};
+use anyhow::{bail, Context as _, Result};
 use clap::clap_app;
+use std::fs;
 
 use turbojpeg::{Transform, TransformOp, Transformer};
 
@@ -31,7 +31,8 @@ fn main() -> Result<()> {
             "Convert the image into grayscale")
         (@arg COPY_NONE: --("copy-none") ...
             "Do not copy any extra markers (such as EXIF data)")
-    ).get_matches();
+    )
+    .get_matches();
 
     let mut transform = Transform::default();
     if let Some(direction) = args.value_of("FLIP") {
@@ -66,11 +67,11 @@ fn main() -> Result<()> {
 
     // TODO: crop
 
-    let jpeg_data = fs::read(args.value_of("INPUT").unwrap())
-        .context("could not read input image")?;
-    let mut transformer = Transformer::new()
-        .context("could not create transformer")?;
-    let transformed_data = transformer.transform_to_owned(&transform, &jpeg_data)
+    let jpeg_data =
+        fs::read(args.value_of("INPUT").unwrap()).context("could not read input image")?;
+    let mut transformer = Transformer::new().context("could not create transformer")?;
+    let transformed_data = transformer
+        .transform_to_owned(&transform, &jpeg_data)
         .context("could not transform JPEG data")?;
     fs::write(args.value_of("OUTPUT").unwrap(), &transformed_data)
         .context("could not write output image")?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.81"
+components = ["rustfmt", "clippy"]

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -1,7 +1,7 @@
-use std::{ptr, slice};
-use std::convert::{AsRef, AsMut};
+use std::convert::{AsMut, AsRef};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
+use std::{ptr, slice};
 
 /// Owned buffer with JPEG data.
 ///
@@ -16,21 +16,32 @@ pub struct OwnedBuf {
 
 impl Deref for OwnedBuf {
     type Target = [u8];
-    fn deref(&self) -> &[u8] { unsafe { deref(self.ptr, self.len) } }
+    fn deref(&self) -> &[u8] {
+        unsafe { deref(self.ptr, self.len) }
+    }
 }
 impl DerefMut for OwnedBuf {
-    fn deref_mut(&mut self) -> &mut [u8] { unsafe { deref_mut(self.ptr, self.len) } }
+    fn deref_mut(&mut self) -> &mut [u8] {
+        unsafe { deref_mut(self.ptr, self.len) }
+    }
 }
 impl AsRef<[u8]> for OwnedBuf {
-    fn as_ref(&self) -> &[u8] { self.deref() }
+    fn as_ref(&self) -> &[u8] {
+        self.deref()
+    }
 }
 impl AsMut<[u8]> for OwnedBuf {
-    fn as_mut(&mut self) -> &mut [u8] { self.deref_mut() }
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.deref_mut()
+    }
 }
 
 impl Default for OwnedBuf {
     fn default() -> Self {
-        Self { ptr: ptr::null_mut(), len: 0 }
+        Self {
+            ptr: ptr::null_mut(),
+            len: 0,
+        }
     }
 }
 
@@ -48,7 +59,10 @@ impl OwnedBuf {
     pub fn allocate(len: usize) -> OwnedBuf {
         let ptr = unsafe { raw::tj3Alloc(len as raw::size_t) };
         assert!(!ptr.is_null(), "tj3Alloc() returned null");
-        OwnedBuf { ptr: ptr as *mut u8, len }
+        OwnedBuf {
+            ptr: ptr as *mut u8,
+            len,
+        }
     }
 
     /// Creates a new buffer copied from a slice.
@@ -75,8 +89,6 @@ impl Drop for OwnedBuf {
     }
 }
 
-
-
 /// Output buffer for JPEG data (borrowed or owned).
 ///
 /// When compressing or transforming images, we need a memory buffer to store the compressed JPEG
@@ -102,18 +114,25 @@ pub struct OutputBuf<'a> {
 
 impl<'a> Deref for OutputBuf<'a> {
     type Target = [u8];
-    fn deref(&self) -> &[u8] { unsafe { deref(self.ptr, self.len) } }
+    fn deref(&self) -> &[u8] {
+        unsafe { deref(self.ptr, self.len) }
+    }
 }
 impl<'a> DerefMut for OutputBuf<'a> {
-    fn deref_mut(&mut self) -> &mut [u8] { unsafe { deref_mut(self.ptr, self.len) } }
+    fn deref_mut(&mut self) -> &mut [u8] {
+        unsafe { deref_mut(self.ptr, self.len) }
+    }
 }
 impl<'a> AsRef<[u8]> for OutputBuf<'a> {
-    fn as_ref(&self) -> &[u8] { self.deref() }
+    fn as_ref(&self) -> &[u8] {
+        self.deref()
+    }
 }
 impl<'a> AsMut<[u8]> for OutputBuf<'a> {
-    fn as_mut(&mut self) -> &mut [u8] { self.deref_mut() }
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.deref_mut()
+    }
 }
-
 
 impl<'a> OutputBuf<'a> {
     /// Converts a slice into a borrowed `OutputBuf`.
@@ -163,14 +182,14 @@ impl<'a> OutputBuf<'a> {
     /// If `self` is owned, this is a trivial operation, otherwise we must copy the data from the
     /// borrowed slice into a new owned buffer.
     pub fn into_owned(mut self) -> OwnedBuf {
-        let OutputBuf { ptr, len, is_owned, .. } = self;
+        let OutputBuf {
+            ptr, len, is_owned, ..
+        } = self;
         self.ptr = ptr::null_mut(); // do not free the pointer in OutputBuf destructor
         if is_owned {
             OwnedBuf { ptr, len }
         } else {
-            unsafe {
-                OwnedBuf::copy_from_slice(slice::from_raw_parts(ptr, len))
-            }
+            unsafe { OwnedBuf::copy_from_slice(slice::from_raw_parts(ptr, len)) }
         }
     }
 }

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -28,10 +28,18 @@ impl AsMut<[u8]> for OwnedBuf {
     fn as_mut(&mut self) -> &mut [u8] { self.deref_mut() }
 }
 
+impl Default for OwnedBuf {
+    fn default() -> Self {
+        Self { ptr: ptr::null_mut(), len: 0 }
+    }
+}
+
 impl OwnedBuf {
     /// Creates an empty buffer.
+    ///
+    /// Alias for [OwnedBuf::default()].
     pub fn new() -> OwnedBuf {
-        OwnedBuf { ptr: ptr::null_mut(), len: 0 }
+        Self::default()
     }
 
     /// Allocates a buffer with given length.
@@ -54,6 +62,11 @@ impl OwnedBuf {
     pub fn len(&self) -> usize {
         self.len
     }
+
+    /// Returns whether the buffer has length 0.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
 }
 
 impl Drop for OwnedBuf {
@@ -71,11 +84,11 @@ impl Drop for OwnedBuf {
 /// from the standard library:
 ///
 /// - Borrowed buffer wraps a `&mut [u8]`, preallocated slice of fixed size provided by you. When
-/// using a borrowed buffer, TurboJPEG cannot resize the buffer, so the operation will fail if the
-/// output does not fit into the buffer.
+///   using a borrowed buffer, TurboJPEG cannot resize the buffer, so the operation will fail if the
+///   output does not fit into the buffer.
 ///
 /// - Owned buffer wraps an [`OwnedBuf`], memory buffer owned by TurboJPEG. This buffer can be
-/// automatically resized to contain the compressed data, so you don't have to worry about its size.
+///   automatically resized to contain the compressed data, so you don't have to worry about its size.
 ///
 /// The lifetime parameter `'a` tracks the lifetime of the borrowed slice. In the case of owned
 /// buffer, the lifetime can be `'static`.
@@ -138,6 +151,11 @@ impl<'a> OutputBuf<'a> {
     /// Returns the length of the buffer.
     pub fn len(&self) -> usize {
         self.len
+    }
+
+    /// Returns whether the buffer has length 0.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     /// Converts this buffer into an owned buffer.

--- a/src/common.rs
+++ b/src/common.rs
@@ -119,7 +119,6 @@ impl PixelFormat {
     }
 }
 
-
 /// Chrominance subsampling options.
 ///
 /// When pixels are converted from RGB to YCbCr or from CMYK to YCCK as part of the JPEG
@@ -315,7 +314,6 @@ impl Subsamp {
     }
 }
 
-
 /// JPEG colorspaces.
 #[doc(alias = "TJCS")]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -387,7 +385,6 @@ impl Colorspace {
     }
 }
 
-
 /// Specialized `Result` type for TurboJPEG.
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -428,4 +425,3 @@ pub enum Error {
     #[error("arguments to a TurboJPEG function were out of bounds")]
     OutOfBounds,
 }
-

--- a/src/common.rs
+++ b/src/common.rs
@@ -205,7 +205,7 @@ pub enum Subsamp {
     ///
     /// - decompressed into planar YUV images,
     /// - losslessly transformed if [`Transform::crop`][crate::Transform::crop] is specified and
-    /// [`Transform::gray`][crate::Transform::gray] is not specified, or
+    ///   [`Transform::gray`][crate::Transform::gray] is not specified, or
     /// - partially decompressed using a cropping region.
     #[doc(alias = "TJSAMP_UNKNOWN")]
     Unknown = raw::TJSAMP_TJSAMP_UNKNOWN,
@@ -398,7 +398,7 @@ pub enum Error {
     /// TurboJPEG returned an error message.
     #[error("TurboJPEG error: {0}")]
     TurboJpegError(String),
-    
+
     /// TurboJPEG unexpectedly returned a null pointer, prehaps because it ran out of memory.
     #[error("TurboJPEG returned null pointer")]
     Null,

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1,8 +1,8 @@
-use std::convert::TryInto as _;
-use crate::{Image, YuvImage, YuvPlanesImage, raw};
-use crate::buf::{OwnedBuf, OutputBuf};
-use crate::common::{Subsamp, Result, Error};
+use crate::buf::{OutputBuf, OwnedBuf};
+use crate::common::{Error, Result, Subsamp};
 use crate::handle::Handle;
+use crate::{raw, Image, YuvImage, YuvPlanesImage};
+use std::convert::TryInto as _;
 
 /// Compresses raw pixel data into JPEG.
 #[derive(Debug)]
@@ -23,8 +23,14 @@ impl Compressor {
     pub fn new() -> Result<Compressor> {
         let mut handle = Handle::new(raw::TJINIT_TJINIT_COMPRESS)?;
         handle.set(raw::TJPARAM_TJPARAM_QUALITY, DEFAULT_QUALITY as libc::c_int)?;
-        handle.set(raw::TJPARAM_TJPARAM_SUBSAMP, DEFAULT_SUBSAMP as i32 as libc::c_int)?;
-        Ok(Compressor { handle, subsamp: DEFAULT_SUBSAMP })
+        handle.set(
+            raw::TJPARAM_TJPARAM_SUBSAMP,
+            DEFAULT_SUBSAMP as i32 as libc::c_int,
+        )?;
+        Ok(Compressor {
+            handle,
+            subsamp: DEFAULT_SUBSAMP,
+        })
     }
 
     /// Set the quality of the compressed JPEG images.
@@ -48,7 +54,8 @@ impl Compressor {
     /// ```
     #[doc(alias = "TJPARAM_QUALITY")]
     pub fn set_quality(&mut self, quality: i32) -> Result<()> {
-        self.handle.set(raw::TJPARAM_TJPARAM_QUALITY, quality as libc::c_int)
+        self.handle
+            .set(raw::TJPARAM_TJPARAM_QUALITY, quality as libc::c_int)
     }
 
     /// Enable/disable lossless compression.
@@ -67,7 +74,8 @@ impl Compressor {
     /// and the value set by this method is overriden.
     #[doc(alias = "TJPARAM_SUBSAMP")]
     pub fn set_subsamp(&mut self, subsamp: Subsamp) -> Result<()> {
-        self.handle.set(raw::TJPARAM_TJPARAM_SUBSAMP, subsamp as i32 as libc::c_int)
+        self.handle
+            .set(raw::TJPARAM_TJPARAM_SUBSAMP, subsamp as i32 as libc::c_int)
     }
 
     /// Enable/disable optimized baseline entropy coding.
@@ -93,7 +101,8 @@ impl Compressor {
     /// ```
     #[doc(alias = "TJPARAM_OPTIMIZE")]
     pub fn set_optimize(&mut self, optimize: bool) -> Result<()> {
-        self.handle.set(raw::TJPARAM_TJPARAM_OPTIMIZE, optimize as libc::c_int)
+        self.handle
+            .set(raw::TJPARAM_TJPARAM_OPTIMIZE, optimize as libc::c_int)
     }
 
     /// Compresses the `image` into `output` buffer.
@@ -128,10 +137,22 @@ impl Compressor {
     pub fn compress(&mut self, image: Image<&[u8]>, output: &mut OutputBuf) -> Result<()> {
         image.assert_valid(image.pixels.len());
 
-        let Image { pixels, width, pitch, height, format } = image;
-        let width = width.try_into().map_err(|_| Error::IntegerOverflow("width"))?;
-        let pitch = pitch.try_into().map_err(|_| Error::IntegerOverflow("pitch"))?;
-        let height = height.try_into().map_err(|_| Error::IntegerOverflow("height"))?;
+        let Image {
+            pixels,
+            width,
+            pitch,
+            height,
+            format,
+        } = image;
+        let width = width
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("width"))?;
+        let pitch = pitch
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("pitch"))?;
+        let height = height
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("height"))?;
 
         self.handle.set(
             raw::TJPARAM_TJPARAM_NOREALLOC,
@@ -141,16 +162,21 @@ impl Compressor {
         let res = unsafe {
             raw::tj3Compress8(
                 self.handle.as_ptr(),
-                pixels.as_ptr(), width, pitch, height, format as libc::c_int,
-                &mut output.ptr, &mut output_len,
+                pixels.as_ptr(),
+                width,
+                pitch,
+                height,
+                format as libc::c_int,
+                &mut output.ptr,
+                &mut output_len,
             )
         };
         output.len = output_len as usize;
         if res != 0 {
-            return Err(self.handle.get_error())
+            return Err(self.handle.get_error());
         } else if output.ptr.is_null() {
             output.len = 0;
-            return Err(Error::Null)
+            return Err(Error::Null);
         }
 
         Ok(())
@@ -237,11 +263,23 @@ impl Compressor {
     pub fn compress_yuv(&mut self, image: YuvImage<&[u8]>, output: &mut OutputBuf) -> Result<()> {
         image.assert_valid(image.pixels.len());
 
-        let YuvImage { pixels, width, align, height, subsamp } = image;
+        let YuvImage {
+            pixels,
+            width,
+            align,
+            height,
+            subsamp,
+        } = image;
         self.set_subsamp(subsamp)?;
-        let width: libc::c_int = width.try_into().map_err(|_| Error::IntegerOverflow("width"))?;
-        let align = align.try_into().map_err(|_| Error::IntegerOverflow("align"))?;
-        let height: libc::c_int = height.try_into().map_err(|_| Error::IntegerOverflow("height"))?;
+        let width: libc::c_int = width
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("width"))?;
+        let align = align
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("align"))?;
+        let height: libc::c_int = height
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("height"))?;
 
         self.handle.set(
             raw::TJPARAM_TJPARAM_NOREALLOC,
@@ -252,16 +290,20 @@ impl Compressor {
         let res = unsafe {
             raw::tj3CompressFromYUV8(
                 self.handle.as_ptr(),
-                pixels.as_ptr(), width, align, height,
-                &mut output.ptr, &mut output_len,
+                pixels.as_ptr(),
+                width,
+                align,
+                height,
+                &mut output.ptr,
+                &mut output_len,
             )
         };
         output.len = output_len as usize;
         if res != 0 {
-            return Err(self.handle.get_error())
+            return Err(self.handle.get_error());
         } else if output.ptr.is_null() {
             output.len = 0;
-            return Err(Error::Null)
+            return Err(Error::Null);
         }
         Ok(())
     }
@@ -291,7 +333,11 @@ impl Compressor {
     /// Returns the size of the compressed JPEG data. If the compressed image does not fit into
     /// `dest`, this method returns an error. Use [`compressed_buf_len()`] to determine buffer size
     /// that is guaranteed to be large enough for the compressed image.
-    pub fn compress_yuv_to_slice(&mut self, image: YuvImage<&[u8]>, output: &mut [u8]) -> Result<usize> {
+    pub fn compress_yuv_to_slice(
+        &mut self,
+        image: YuvImage<&[u8]>,
+        output: &mut [u8],
+    ) -> Result<usize> {
         let mut buf = OutputBuf::borrowed(output);
         self.compress_yuv(image, &mut buf)?;
         Ok(buf.len())
@@ -299,8 +345,8 @@ impl Compressor {
 
     /// Compress separate YUV planes into JPEG.
     ///
-    /// This function compresses separate Y, U (Cb), and V (Cr) image planes into 
-    /// a JPEG image. This is similar to [`compress_yuv()`][Self::compress_yuv], 
+    /// This function compresses separate Y, U (Cb), and V (Cr) image planes into
+    /// a JPEG image. This is similar to [`compress_yuv()`][Self::compress_yuv],
     /// but takes separate YUV planes as input instead of interleaved YUV data.
     ///
     /// # Arguments
@@ -347,9 +393,19 @@ impl Compressor {
         image: &YuvPlanesImage<&[u8]>,
         output: &mut OutputBuf,
     ) -> Result<()> {
-        image.assert_valid(image.y_plane.len(), image.u_plane.len(), image.v_plane.len());
-        let width = image.width.try_into().map_err(|_| Error::IntegerOverflow("width"))?;
-        let height = image.height.try_into().map_err(|_| Error::IntegerOverflow("height"))?;
+        image.assert_valid(
+            image.y_plane.len(),
+            image.u_plane.len(),
+            image.v_plane.len(),
+        );
+        let width = image
+            .width
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("width"))?;
+        let height = image
+            .height
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("height"))?;
 
         let planes = [
             image.y_plane.as_ptr(),
@@ -358,11 +414,20 @@ impl Compressor {
         ];
 
         let strides = [
-            image.y_stride.try_into().map_err(|_| Error::IntegerOverflow("y_stride"))?,
-            image.u_stride.try_into().map_err(|_| Error::IntegerOverflow("u_stride"))?,
-            image.v_stride.try_into().map_err(|_| Error::IntegerOverflow("v_stride"))?,
+            image
+                .y_stride
+                .try_into()
+                .map_err(|_| Error::IntegerOverflow("y_stride"))?,
+            image
+                .u_stride
+                .try_into()
+                .map_err(|_| Error::IntegerOverflow("u_stride"))?,
+            image
+                .v_stride
+                .try_into()
+                .map_err(|_| Error::IntegerOverflow("v_stride"))?,
         ];
-        
+
         // Set subsampling from the YuvPlanesImage structure
         self.set_subsamp(image.subsamp)?;
 
@@ -412,10 +477,7 @@ impl Compressor {
     /// This method copies the compressed data into a new `Vec`. If you would like to avoid the
     /// extra allocation and copying, consider using
     /// [`compress_yuv_planes_to_owned()`][Self::compress_yuv_planes_to_owned] instead.
-    pub fn compress_yuv_planes_to_vec(
-        &mut self,
-        image: &YuvPlanesImage<&[u8]>,
-    ) -> Result<Vec<u8>> {
+    pub fn compress_yuv_planes_to_vec(&mut self, image: &YuvPlanesImage<&[u8]>) -> Result<Vec<u8>> {
         let mut buf = OutputBuf::new_owned();
         self.compress_yuv_planes(image, &mut buf)?;
         Ok(buf.to_vec())
@@ -436,7 +498,6 @@ impl Compressor {
         Ok(buf.len())
     }
 
-
     /// Compute the maximum size of a compressed image.
     ///
     /// This depends on image `width` and `height`, and also on the current setting of chrominance
@@ -450,7 +511,7 @@ impl Compressor {
 }
 
 /// Compress an image to JPEG.
-/// 
+///
 /// Uses the given quality and chrominance subsampling option and returns the JPEG data in a buffer
 /// owned by TurboJPEG. If this function does not fit your needs, please see [`Compressor`].
 ///
@@ -552,9 +613,15 @@ pub fn compress_yuv_planes(image: &YuvPlanesImage<&[u8]>, quality: i32) -> Resul
 /// about this edge case.
 #[doc(alias = "tj3JPEGBufSize")]
 pub fn compressed_buf_len(width: usize, height: usize, subsamp: Subsamp) -> Result<usize> {
-    let width = width.try_into().map_err(|_| Error::IntegerOverflow("width"))?;
-    let height = height.try_into().map_err(|_| Error::IntegerOverflow("height"))?;
+    let width = width
+        .try_into()
+        .map_err(|_| Error::IntegerOverflow("width"))?;
+    let height = height
+        .try_into()
+        .map_err(|_| Error::IntegerOverflow("height"))?;
     let len = unsafe { raw::tj3JPEGBufSize(width, height, subsamp as libc::c_int) };
-    let len = len.try_into().map_err(|_| Error::IntegerOverflow("buf len"))?;
+    let len = len
+        .try_into()
+        .map_err(|_| Error::IntegerOverflow("buf len"))?;
     Ok(len)
 }

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -1,9 +1,9 @@
-use std::convert::TryInto as _;
-use std::fmt;
-use crate::{Image, YuvImage, raw};
-use crate::common::{PixelFormat, Subsamp, Colorspace, Result, Error};
+use crate::common::{Colorspace, Error, PixelFormat, Result, Subsamp};
 use crate::handle::Handle;
 use crate::image_internal::yuv_pixels_len;
+use crate::{raw, Image, YuvImage};
+use std::convert::TryInto as _;
+use std::fmt;
 
 /// Decompresses JPEG data into raw pixels.
 #[derive(Debug)]
@@ -73,7 +73,10 @@ impl ScalingFactor {
     /// ```
     pub fn new(num: usize, denom: usize) -> Self {
         let gcd = gcd::binary_usize(num, denom);
-        Self { num: num / gcd, denom: denom / gcd }
+        Self {
+            num: num / gcd,
+            denom: denom / gcd,
+        }
     }
 
     /// Get the numerator (the "3" in "3/4").
@@ -130,7 +133,7 @@ impl DecompressHeader {
         Self {
             width: factor.scale(self.width),
             height: factor.scale(self.height),
-            .. *self
+            ..*self
         }
     }
 }
@@ -140,7 +143,10 @@ impl Decompressor {
     #[doc(alias = "tj3Init")]
     pub fn new() -> Result<Decompressor> {
         let handle = Handle::new(raw::TJINIT_TJINIT_DECOMPRESS)?;
-        Ok(Self { handle, scaling_factor: ScalingFactor::ONE })
+        Ok(Self {
+            handle,
+            scaling_factor: ScalingFactor::ONE,
+        })
     }
 
     /// Read the JPEG header without decompressing the image.
@@ -162,23 +168,37 @@ impl Decompressor {
     /// ```
     #[doc(alias = "tj3DecompressHeader")]
     pub fn read_header(&mut self, jpeg_data: &[u8]) -> Result<DecompressHeader> {
-        let jpeg_data_len = jpeg_data.len().try_into()
+        let jpeg_data_len = jpeg_data
+            .len()
+            .try_into()
             .map_err(|_| Error::IntegerOverflow("jpeg_data.len()"))?;
         let res = unsafe {
             raw::tj3DecompressHeader(self.handle.as_ptr(), jpeg_data.as_ptr(), jpeg_data_len)
         };
         if res != 0 {
-            return Err(self.handle.get_error())
+            return Err(self.handle.get_error());
         }
 
-        let width = self.handle.get(raw::TJPARAM_TJPARAM_JPEGWIDTH)
-            .try_into().map_err(|_| Error::IntegerOverflow("width"))?;
-        let height = self.handle.get(raw::TJPARAM_TJPARAM_JPEGHEIGHT)
-            .try_into().map_err(|_| Error::IntegerOverflow("height"))?;
+        let width = self
+            .handle
+            .get(raw::TJPARAM_TJPARAM_JPEGWIDTH)
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("width"))?;
+        let height = self
+            .handle
+            .get(raw::TJPARAM_TJPARAM_JPEGHEIGHT)
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("height"))?;
         let subsamp = Subsamp::from_int(self.handle.get(raw::TJPARAM_TJPARAM_SUBSAMP))?;
         let colorspace = Colorspace::from_int(self.handle.get(raw::TJPARAM_TJPARAM_COLORSPACE))?;
         let is_lossless = self.handle.get(raw::TJPARAM_TJPARAM_LOSSLESS) != 0;
-        Ok(DecompressHeader { width, height, subsamp, colorspace, is_lossless })
+        Ok(DecompressHeader {
+            width,
+            height,
+            subsamp,
+            colorspace,
+            is_lossless,
+        })
     }
 
     /// Set scaling factor for subsequent decompression operations.
@@ -219,11 +239,16 @@ impl Decompressor {
     /// ```
     #[doc(alias = "tj3SetScalingFactor")]
     pub fn set_scaling_factor(&mut self, scaling_factor: ScalingFactor) -> Result<()> {
-        let num: libc::c_int = scaling_factor.num.try_into()
+        let num: libc::c_int = scaling_factor
+            .num
+            .try_into()
             .map_err(|_| Error::IntegerOverflow("num"))?;
-        let denom: libc::c_int = scaling_factor.denom.try_into()
+        let denom: libc::c_int = scaling_factor
+            .denom
+            .try_into()
             .map_err(|_| Error::IntegerOverflow("denom"))?;
-        self.handle.set_scaling_factor(raw::tjscalingfactor { num, denom })?;
+        self.handle
+            .set_scaling_factor(raw::tjscalingfactor { num, denom })?;
         self.scaling_factor = scaling_factor;
         Ok(())
     }
@@ -270,11 +295,25 @@ impl Decompressor {
     #[doc(alias = "tj3Decompress8")]
     pub fn decompress(&mut self, jpeg_data: &[u8], output: Image<&mut [u8]>) -> Result<()> {
         output.assert_valid(output.pixels.len());
-        let Image { pixels, width, pitch, height, format } = output;
-        let width: libc::c_int = width.try_into().map_err(|_| Error::IntegerOverflow("width"))?;
-        let pitch: libc::c_int = pitch.try_into().map_err(|_| Error::IntegerOverflow("pitch"))?;
-        let height: libc::c_int = height.try_into().map_err(|_| Error::IntegerOverflow("height"))?;
-        let jpeg_data_len: raw::size_t = jpeg_data.len().try_into()
+        let Image {
+            pixels,
+            width,
+            pitch,
+            height,
+            format,
+        } = output;
+        let width: libc::c_int = width
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("width"))?;
+        let pitch: libc::c_int = pitch
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("pitch"))?;
+        let height: libc::c_int = height
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("height"))?;
+        let jpeg_data_len: raw::size_t = jpeg_data
+            .len()
+            .try_into()
             .map_err(|_| Error::IntegerOverflow("jpeg_data.len()"))?;
 
         self.check_output_size(jpeg_data, width, height)?;
@@ -282,12 +321,15 @@ impl Decompressor {
         let res = unsafe {
             raw::tj3Decompress8(
                 self.handle.as_ptr(),
-                jpeg_data.as_ptr(), jpeg_data_len,
-                pixels.as_mut_ptr(), pitch, format as i32,
+                jpeg_data.as_ptr(),
+                jpeg_data_len,
+                pixels.as_mut_ptr(),
+                pitch,
+                format as i32,
             )
         };
         if res != 0 {
-            return Err(self.handle.get_error())
+            return Err(self.handle.get_error());
         }
 
         Ok(())
@@ -331,13 +373,31 @@ impl Decompressor {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[doc(alias = "tj3DecompressToYUV8")]
-    pub fn decompress_to_yuv(&mut self, jpeg_data: &[u8], output: YuvImage<&mut [u8]>) -> Result<()> {
+    pub fn decompress_to_yuv(
+        &mut self,
+        jpeg_data: &[u8],
+        output: YuvImage<&mut [u8]>,
+    ) -> Result<()> {
         output.assert_valid(output.pixels.len());
-        let YuvImage { pixels, width, align, height, subsamp: _ } = output;
-        let width: libc::c_int = width.try_into().map_err(|_| Error::IntegerOverflow("width"))?;
-        let align: libc::c_int = align.try_into().map_err(|_| Error::IntegerOverflow("align"))?;
-        let height: libc::c_int = height.try_into().map_err(|_| Error::IntegerOverflow("height"))?;
-        let jpeg_data_len: raw::size_t = jpeg_data.len().try_into()
+        let YuvImage {
+            pixels,
+            width,
+            align,
+            height,
+            subsamp: _,
+        } = output;
+        let width: libc::c_int = width
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("width"))?;
+        let align: libc::c_int = align
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("align"))?;
+        let height: libc::c_int = height
+            .try_into()
+            .map_err(|_| Error::IntegerOverflow("height"))?;
+        let jpeg_data_len: raw::size_t = jpeg_data
+            .len()
+            .try_into()
             .map_err(|_| Error::IntegerOverflow("jpeg_data.len()"))?;
 
         self.check_output_size(jpeg_data, width, height)?;
@@ -345,28 +405,38 @@ impl Decompressor {
         let res = unsafe {
             raw::tj3DecompressToYUV8(
                 self.handle.as_ptr(),
-                jpeg_data.as_ptr(), jpeg_data_len,
-                pixels.as_mut_ptr(), align,
+                jpeg_data.as_ptr(),
+                jpeg_data_len,
+                pixels.as_mut_ptr(),
+                align,
             )
         };
         if res != 0 {
-            return Err(self.handle.get_error())
+            return Err(self.handle.get_error());
         }
 
         Ok(())
     }
 
-    fn check_output_size(&mut self, jpeg_data: &[u8], width: libc::c_int, height: libc::c_int) -> Result<()> {
+    fn check_output_size(
+        &mut self,
+        jpeg_data: &[u8],
+        width: libc::c_int,
+        height: libc::c_int,
+    ) -> Result<()> {
         let header = self.read_header(jpeg_data)?;
 
         if header.is_lossless && self.scaling_factor != ScalingFactor::ONE {
-            return Err(Error::CannotScaleLossless)
+            return Err(Error::CannotScaleLossless);
         }
         let scaled_width = self.scaling_factor.scale(header.width);
         let scaled_height = self.scaling_factor.scale(header.height);
 
         if width < scaled_width as i32 || height < scaled_height as i32 {
-            return Err(Error::OutputTooSmall(scaled_width as i32, scaled_height as i32))
+            return Err(Error::OutputTooSmall(
+                scaled_width as i32,
+                scaled_height as i32,
+            ));
         }
 
         Ok(())
@@ -390,18 +460,22 @@ impl Decompressor {
     #[doc(alias = "tj3GetScalingFactors")]
     pub fn supported_scaling_factors() -> Vec<ScalingFactor> {
         let mut count: libc::c_int = 0;
-        let ptr: *const raw::tjscalingfactor = unsafe {
-            raw::tj3GetScalingFactors(&mut count as *mut _)
-        };
-        let count: usize = count.try_into()
+        let ptr: *const raw::tjscalingfactor =
+            unsafe { raw::tj3GetScalingFactors(&mut count as *mut _) };
+        let count: usize = count
+            .try_into()
             .expect("tj3GetScalingFactors() returned a number that cannot be converted to usize");
 
         let mut list = Vec::with_capacity(count);
         for i in 0..count {
             let factor = unsafe { ptr.add(i).read() };
-            let num: usize = factor.num.try_into()
+            let num: usize = factor
+                .num
+                .try_into()
                 .expect("Numerator of a tjscalingfactor cannot be converted to usize");
-            let denom: usize = factor.denom.try_into()
+            let denom: usize = factor
+                .denom
+                .try_into()
                 .expect("Denominator of a tjscalingfactor cannot be converted to usize");
             list.push(ScalingFactor { num, denom });
         }
@@ -467,12 +541,7 @@ pub fn decompress_to_yuv(jpeg_data: &[u8]) -> Result<YuvImage<Vec<u8>>> {
     let mut decompressor = Decompressor::new()?;
     let header = decompressor.read_header(jpeg_data)?;
     let align = 4;
-    let yuv_pixels_len = yuv_pixels_len(
-        header.width,
-        align,
-        header.height,
-        header.subsamp,
-    )?;
+    let yuv_pixels_len = yuv_pixels_len(header.width, align, header.height, header.subsamp)?;
 
     let mut yuv_image = YuvImage {
         pixels: vec![0; yuv_pixels_len],

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,6 +1,6 @@
-use std::ffi::CStr;
-use crate::common::{Result, Error};
+use crate::common::{Error, Result};
 use crate::raw;
+use std::ffi::CStr;
 
 #[derive(Debug)]
 pub struct Handle {
@@ -12,7 +12,7 @@ impl Handle {
         let ptr = unsafe { raw::tj3Init(init as libc::c_int) };
         let mut this = Self { ptr };
         if this.ptr.is_null() {
-            return Err(this.get_error())
+            return Err(this.get_error());
         }
         Ok(this)
     }
@@ -29,7 +29,7 @@ impl Handle {
     pub fn set(&mut self, param: raw::TJPARAM, value: libc::c_int) -> Result<()> {
         let res = unsafe { raw::tj3Set(self.ptr, param as libc::c_int, value) };
         if res != 0 {
-            return Err(self.get_error())
+            return Err(self.get_error());
         }
         Ok(())
     }
@@ -37,7 +37,7 @@ impl Handle {
     pub fn set_scaling_factor(&mut self, scaling_factor: raw::tjscalingfactor) -> Result<()> {
         let res = unsafe { raw::tj3SetScalingFactor(self.ptr, scaling_factor) };
         if res != 0 {
-            return Err(self.get_error())
+            return Err(self.get_error());
         }
         Ok(())
     }
@@ -49,6 +49,8 @@ impl Handle {
 
 impl Drop for Handle {
     fn drop(&mut self) {
-        unsafe { raw::tj3Destroy(self.ptr); }
+        unsafe {
+            raw::tj3Destroy(self.ptr);
+        }
     }
 }

--- a/src/image_internal.rs
+++ b/src/image_internal.rs
@@ -1,5 +1,5 @@
+use crate::common::{Error, PixelFormat, Result, Subsamp};
 use std::ops::{Deref, DerefMut};
-use crate::common::{PixelFormat, Subsamp, Result, Error};
 
 /// An image with pixels of type `T`.
 ///
@@ -34,7 +34,10 @@ impl<T> Image<T> {
     /// Converts from `&Image<T>` to `Image<&T::Target>`.
     ///
     /// In particular, you can use this to get `Image<&[u8]>` from `Image<Vec<u8>>`.
-    pub fn as_deref(&self) -> Image<&T::Target> where T: Deref {
+    pub fn as_deref(&self) -> Image<&T::Target>
+    where
+        T: Deref,
+    {
         Image {
             pixels: self.pixels.deref(),
             width: self.width,
@@ -47,7 +50,10 @@ impl<T> Image<T> {
     /// Converts from `&mut Image<T>` to `Image<&mut T::Target>`.
     ///
     /// In particular, you can use this to get `Image<&mut [u8]>` from `Image<Vec<u8>>`.
-    pub fn as_deref_mut(&mut self) -> Image<&mut T::Target> where T: DerefMut {
+    pub fn as_deref_mut(&mut self) -> Image<&mut T::Target>
+    where
+        T: DerefMut,
+    {
         Image {
             pixels: self.pixels.deref_mut(),
             width: self.width,
@@ -58,12 +64,29 @@ impl<T> Image<T> {
     }
 
     pub(crate) fn assert_valid(&self, pixels_len: usize) {
-        let Image { pixels: _, width, pitch, height, format } = *self;
-        assert!(pitch >= width*format.size(),
-            "pitch {} is too small for width {} and pixel format {:?}", pitch, width, format);
-        assert!(height == 0 || pitch*(height - 1) + width*format.size() <= pixels_len,
+        let Image {
+            pixels: _,
+            width,
+            pitch,
+            height,
+            format,
+        } = *self;
+        assert!(
+            pitch >= width * format.size(),
+            "pitch {} is too small for width {} and pixel format {:?}",
+            pitch,
+            width,
+            format
+        );
+        assert!(
+            height == 0 || pitch * (height - 1) + width * format.size() <= pixels_len,
             "pixels length {} is too small for width {}, height {}, pitch {} and pixel format {:?}",
-            pixels_len, width, height, pitch, format);
+            pixels_len,
+            width,
+            height,
+            pitch,
+            format
+        );
     }
 }
 
@@ -101,9 +124,9 @@ impl Image<Vec<u8>> {
             let max_iters = 100;
             let (mut x, mut y) = (set_x, set_y);
             let mut iters = 0;
-            while x*x + y*y <= 4. && iters < max_iters {
-                let next_x = x*x - y*y + set_x;
-                let next_y = 2.*x*y + set_y;
+            while x * x + y * y <= 4. && iters < max_iters {
+                let next_x = x * x - y * y + set_x;
+                let next_y = 2. * x * y + set_y;
                 x = next_x;
                 y = next_y;
                 iters += 1;
@@ -113,11 +136,24 @@ impl Image<Vec<u8>> {
 
         // convert the f64 values to pixel values
 
-        fn assign_rgba(r: usize, g: usize, b: usize, a: Option<usize>, data: &mut [u8], value: f64) {
-            data[b] = quantize(f64::clamp(f64::min(3.*value, 3. - 3.*value), 0., 1.));
-            data[r] = quantize(f64::clamp(f64::max(1. - 3.*value, 3.*value - 2.), 0., 1.));
+        fn assign_rgba(
+            r: usize,
+            g: usize,
+            b: usize,
+            a: Option<usize>,
+            data: &mut [u8],
+            value: f64,
+        ) {
+            data[b] = quantize(f64::clamp(f64::min(3. * value, 3. - 3. * value), 0., 1.));
+            data[r] = quantize(f64::clamp(
+                f64::max(1. - 3. * value, 3. * value - 2.),
+                0.,
+                1.,
+            ));
             data[g] = quantize(f64::clamp(value, 0., 1.));
-            if let Some(a) = a { data[a] = 255; }
+            if let Some(a) = a {
+                data[a] = 255;
+            }
         }
 
         fn assign_gray(data: &mut [u8], value: f64) {
@@ -128,25 +164,24 @@ impl Image<Vec<u8>> {
             (value * 255.) as u8
         }
 
-
         let pixel_size = format.size();
         let assign_fn: &dyn Fn(&mut [u8], f64) = match format {
-            PixelFormat::RGB =>
-                &|data, value| assign_rgba(0,1,2,None, data, value),
-            PixelFormat::BGR =>
-                &|data, value| assign_rgba(2,1,0,None, data, value),
-            PixelFormat::RGBX | PixelFormat::RGBA =>
-                &|data, value| assign_rgba(0,1,2,Some(3), data, value),
-            PixelFormat::BGRX | PixelFormat::BGRA =>
-                &|data, value| assign_rgba(2,1,0,Some(3), data, value),
-            PixelFormat::XRGB | PixelFormat::ARGB =>
-                &|data, value| assign_rgba(1,2,3,Some(0), data, value),
-            PixelFormat::XBGR | PixelFormat::ABGR =>
-                &|data, value| assign_rgba(3,2,1,Some(0), data, value),
-            PixelFormat::GRAY =>
-                &assign_gray,
-            PixelFormat::CMYK =>
-                &|data, value| assign_rgba(0,1,2,Some(3), data, value),
+            PixelFormat::RGB => &|data, value| assign_rgba(0, 1, 2, None, data, value),
+            PixelFormat::BGR => &|data, value| assign_rgba(2, 1, 0, None, data, value),
+            PixelFormat::RGBX | PixelFormat::RGBA => {
+                &|data, value| assign_rgba(0, 1, 2, Some(3), data, value)
+            }
+            PixelFormat::BGRX | PixelFormat::BGRA => {
+                &|data, value| assign_rgba(2, 1, 0, Some(3), data, value)
+            }
+            PixelFormat::XRGB | PixelFormat::ARGB => {
+                &|data, value| assign_rgba(1, 2, 3, Some(0), data, value)
+            }
+            PixelFormat::XBGR | PixelFormat::ABGR => {
+                &|data, value| assign_rgba(3, 2, 1, Some(0), data, value)
+            }
+            PixelFormat::GRAY => &assign_gray,
+            PixelFormat::CMYK => &|data, value| assign_rgba(0, 1, 2, Some(3), data, value),
         };
 
         // generate the image
@@ -159,11 +194,17 @@ impl Image<Vec<u8>> {
             for x in 0..width {
                 let (set_x, set_y) = pixel_to_set(x, y);
                 let value = eval_set(set_x, set_y);
-                assign_fn(&mut pixels[y*pitch + pixel_size*x..], value);
+                assign_fn(&mut pixels[y * pitch + pixel_size * x..], value);
             }
         }
 
-        Image { pixels, width, pitch, height, format }
+        Image {
+            pixels,
+            width,
+            pitch,
+            height,
+            format,
+        }
     }
 }
 
@@ -235,7 +276,10 @@ impl<T> YuvImage<T> {
     /// Converts from `&YuvImage<T>` to `YuvImage<&T::Target>`.
     ///
     /// In particular, you can use this to get `YuvImage<&[u8]>` from `YuvImage<Vec<u8>>`.
-    pub fn as_deref(&self) -> YuvImage<&T::Target> where T: Deref {
+    pub fn as_deref(&self) -> YuvImage<&T::Target>
+    where
+        T: Deref,
+    {
         YuvImage {
             pixels: self.pixels.deref(),
             width: self.width,
@@ -248,7 +292,10 @@ impl<T> YuvImage<T> {
     /// Converts from `&mut YuvImage<T>` to `YuvImage<&mut T::Target>`.
     ///
     /// In particular, you can use this to get `YuvImage<&mut [u8]>` from `YuvImage<Vec<u8>>`.
-    pub fn as_deref_mut(&mut self) -> YuvImage<&mut T::Target> where T: DerefMut {
+    pub fn as_deref_mut(&mut self) -> YuvImage<&mut T::Target>
+    where
+        T: DerefMut,
+    {
         YuvImage {
             pixels: self.pixels.deref_mut(),
             width: self.width,
@@ -303,11 +350,23 @@ impl<T> YuvImage<T> {
     }
 
     pub(crate) fn assert_valid(&self, pixels_len: usize) {
-        let YuvImage { pixels: _, width, align, height, subsamp } = *self;
+        let YuvImage {
+            pixels: _,
+            width,
+            align,
+            height,
+            subsamp,
+        } = *self;
         let min_yuv_pixels_len = yuv_pixels_len(width, align, height, subsamp).unwrap();
-        assert!(min_yuv_pixels_len <= pixels_len,
+        assert!(
+            min_yuv_pixels_len <= pixels_len,
             "YUV pixels length {} is too small for width {}, height {}, align {} and subsamp {:?}",
-            pixels_len, width, height, align, subsamp);
+            pixels_len,
+            width,
+            height,
+            align,
+            subsamp
+        );
     }
 }
 
@@ -335,10 +394,21 @@ impl<T> YuvImage<T> {
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[doc(alias = "tj3YUVBufSize")]
-pub fn yuv_pixels_len(width: usize, align: usize, height: usize, subsamp: Subsamp) -> Result<usize> {
-    let width = width.try_into().map_err(|_| Error::IntegerOverflow("width"))?;
-    let align = align.try_into().map_err(|_| Error::IntegerOverflow("align"))?;
-    let height = height.try_into().map_err(|_| Error::IntegerOverflow("height"))?;
+pub fn yuv_pixels_len(
+    width: usize,
+    align: usize,
+    height: usize,
+    subsamp: Subsamp,
+) -> Result<usize> {
+    let width = width
+        .try_into()
+        .map_err(|_| Error::IntegerOverflow("width"))?;
+    let align = align
+        .try_into()
+        .map_err(|_| Error::IntegerOverflow("align"))?;
+    let height = height
+        .try_into()
+        .map_err(|_| Error::IntegerOverflow("height"))?;
     let len = unsafe { raw::tj3YUVBufSize(width, align, height, subsamp as libc::c_int) };
     match len.try_into() {
         Ok(0) => Err(Error::OutOfBounds),
@@ -346,7 +416,6 @@ pub fn yuv_pixels_len(width: usize, align: usize, height: usize, subsamp: Subsam
         Err(_) => Err(Error::IntegerOverflow("yuv size")),
     }
 }
-
 
 /// A YUV (YCbCr) image with separate planes.
 ///
@@ -383,7 +452,10 @@ pub struct YuvPlanesImage<T> {
 
 impl<T> YuvPlanesImage<T> {
     /// Converts from `&YuvPlanesImage<T>` to `YuvPlanesImage<&T::Target>`.
-    pub fn as_deref(&self) -> YuvPlanesImage<&T::Target> where T: Deref {
+    pub fn as_deref(&self) -> YuvPlanesImage<&T::Target>
+    where
+        T: Deref,
+    {
         YuvPlanesImage {
             y_plane: self.y_plane.deref(),
             u_plane: self.u_plane.deref(),
@@ -425,22 +497,51 @@ impl<T> YuvPlanesImage<T> {
     }
 
     pub(crate) fn assert_valid(&self, y_len: usize, u_len: usize, v_len: usize) {
-        let YuvPlanesImage { width, height, y_stride, u_stride, v_stride, subsamp, .. } = *self;
+        let YuvPlanesImage {
+            width,
+            height,
+            y_stride,
+            u_stride,
+            v_stride,
+            subsamp,
+            ..
+        } = *self;
 
-        let min_y_plane_len = yuv_plane_len(YuvComponent::Y, width, y_stride, height, subsamp).unwrap();
-        assert!(min_y_plane_len <= y_len,
+        let min_y_plane_len =
+            yuv_plane_len(YuvComponent::Y, width, y_stride, height, subsamp).unwrap();
+        assert!(
+            min_y_plane_len <= y_len,
             "Y plane length {} is too small for width {}, height {}, stride {} and subsamp {:?}",
-            y_len, width, height, y_stride, subsamp);
+            y_len,
+            width,
+            height,
+            y_stride,
+            subsamp
+        );
 
-        let min_u_plane_len = yuv_plane_len(YuvComponent::U, width, u_stride, height, subsamp).unwrap();
-        assert!(min_u_plane_len <= u_len,
+        let min_u_plane_len =
+            yuv_plane_len(YuvComponent::U, width, u_stride, height, subsamp).unwrap();
+        assert!(
+            min_u_plane_len <= u_len,
             "U plane length {} is too small for width {}, height {}, stride {} and subsamp {:?}",
-            u_len, width, height, u_stride, subsamp);
+            u_len,
+            width,
+            height,
+            u_stride,
+            subsamp
+        );
 
-        let min_v_plane_len = yuv_plane_len(YuvComponent::V, width, v_stride, height, subsamp).unwrap();
-        assert!(min_v_plane_len <= v_len,
+        let min_v_plane_len =
+            yuv_plane_len(YuvComponent::V, width, v_stride, height, subsamp).unwrap();
+        assert!(
+            min_v_plane_len <= v_len,
             "V plane length {} is too small for width {}, height {}, stride {} and subsamp {:?}",
-            v_len, width, height, v_stride, subsamp);
+            v_len,
+            width,
+            height,
+            v_stride,
+            subsamp
+        );
     }
 }
 
@@ -467,13 +568,21 @@ pub fn yuv_plane_len(
     height: usize,
     subsamp: Subsamp,
 ) -> Result<usize> {
-    let width = width.try_into().map_err(|_| Error::IntegerOverflow("width"))?;
-    let stride = stride.try_into().map_err(|_| Error::IntegerOverflow("stride"))?;
-    let height = height.try_into().map_err(|_| Error::IntegerOverflow("height"))?;
+    let width = width
+        .try_into()
+        .map_err(|_| Error::IntegerOverflow("width"))?;
+    let stride = stride
+        .try_into()
+        .map_err(|_| Error::IntegerOverflow("stride"))?;
+    let height = height
+        .try_into()
+        .map_err(|_| Error::IntegerOverflow("height"))?;
     let len = unsafe {
         raw::tj3YUVPlaneSize(
             component as libc::c_int,
-            width, stride, height,
+            width,
+            stride,
+            height,
             subsamp as libc::c_int,
         )
     };

--- a/src/image_internal.rs
+++ b/src/image_internal.rs
@@ -6,11 +6,11 @@ use crate::common::{PixelFormat, Subsamp, Result, Error};
 /// Three variants of this type are commonly used:
 ///
 /// - `Image<&[u8]>`: immutable reference to image data (input image for compression by
-/// [`Compressor`][crate::Compressor])
+///   [`Compressor`][crate::Compressor])
 /// - `Image<&mut [u8]>`: mutable reference to image data (output image for decompression by
-/// [`Decompressor`][crate::Decompressor]).
+///   [`Decompressor`][crate::Decompressor]).
 /// - `Image<Vec<u8>>`: owned image data (you can convert it to a reference using
-/// [`.as_deref()`][Image::as_deref] or [`.as_deref_mut()`][Image::as_deref_mut]).
+///   [`.as_deref()`][Image::as_deref] or [`.as_deref_mut()`][Image::as_deref_mut]).
 ///
 /// Data for pixel in column `x` and row `y` is stored in `pixels` at offset `y*pitch +
 /// x*format.size()`.
@@ -175,9 +175,9 @@ impl Image<Vec<u8>> {
 /// Two variants of this type are commonly used:
 ///
 /// - `YuvImage<&mut [u8]>`: mutable reference to YUV image data (output image for decompression by
-/// [`Decompressor`][crate::Decompressor]).
+///   [`Decompressor`][crate::Decompressor]).
 /// - `YuvImage<Vec<u8>>`: owned YUV image data (you can convert it to a reference using
-/// [`.as_deref()`][YuvImage::as_deref] or [`.as_deref_mut()`][YuvImage::as_deref_mut]).
+///   [`.as_deref()`][YuvImage::as_deref] or [`.as_deref_mut()`][YuvImage::as_deref_mut]).
 ///
 /// # Image format
 ///
@@ -185,13 +185,13 @@ impl Image<Vec<u8>> {
 /// [chrominance subsampling][Self::subsamp] and [row alignment][Self::align] of the image:
 ///
 /// - [Luminance (Y) plane width][Self::y_width()] is the image width padded to the nearest
-/// multiple of the [horizontal subsampling factor][Subsamp::width()].
+///   multiple of the [horizontal subsampling factor][Subsamp::width()].
 /// - [Luminance (Y) plane height][Self::y_height()] is the image height padded to the nearest
-/// multiple of the [vertical subsampling factor][Subsamp::height()].
+///   multiple of the [vertical subsampling factor][Subsamp::height()].
 /// - [Chrominance (U and V) plane width][Self::uv_width()] is the luminance plane width divided by
-/// the horizontal subsampling factor.
+///   the horizontal subsampling factor.
 /// - [Chrominance (U and V) plane height][Self::uv_height()] is the luminance plane height divided
-/// by the vertical subsampling factor.
+///   by the vertical subsampling factor.
 /// - Each row is further padded to the nearest multiple of the [row alignment][Self::align].
 ///
 /// ## Example
@@ -318,7 +318,7 @@ impl<T> YuvImage<T> {
 ///
 /// Returns an error on integer overflow. You can just `.unwrap()` the result if you don't care
 /// about this edge case.
-/// 
+///
 /// # Example
 ///
 /// ```

--- a/src/image_rs.rs
+++ b/src/image_rs.rs
@@ -1,8 +1,8 @@
-use crate::Image;
 use crate::buf::OwnedBuf;
-use crate::compress::Compressor;
 use crate::common::{PixelFormat, Result, Subsamp};
+use crate::compress::Compressor;
 use crate::decompress::Decompressor;
+use crate::Image;
 
 /// Decompresses image from JPEG into an [`image::ImageBuffer`].
 ///
@@ -19,7 +19,8 @@ use crate::decompress::Decompressor;
 /// ```
 #[cfg_attr(docsrs, doc(cfg(feature = "image")))]
 pub fn decompress_image<P>(jpeg_data: &[u8]) -> Result<image::ImageBuffer<P, Vec<u8>>>
-    where P: JpegPixel + 'static
+where
+    P: JpegPixel + 'static,
 {
     let mut decompressor = Decompressor::new()?;
     let header = decompressor.read_header(jpeg_data)?;
@@ -35,11 +36,9 @@ pub fn decompress_image<P>(jpeg_data: &[u8]) -> Result<image::ImageBuffer<P, Vec
     };
     decompressor.decompress(jpeg_data, image)?;
 
-    let image_buf = image::ImageBuffer::from_raw(
-        header.width as u32,
-        header.height as u32,
-        image_data,
-    ).unwrap();
+    let image_buf =
+        image::ImageBuffer::from_raw(header.width as u32, header.height as u32, image_data)
+            .unwrap();
     Ok(image_buf)
 }
 
@@ -73,7 +72,8 @@ pub fn compress_image<P>(
     quality: i32,
     subsamp: Subsamp,
 ) -> Result<OwnedBuf>
-    where P: JpegPixel + 'static
+where
+    P: JpegPixel + 'static,
 {
     let (width, height) = image_buf.dimensions();
     let format = P::PIXEL_FORMAT;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,10 +93,10 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-pub extern crate turbojpeg_sys as raw;
-pub extern crate libc;
 #[cfg(feature = "image")]
 pub extern crate image as image;
+pub extern crate libc;
+pub extern crate turbojpeg_sys as raw;
 
 mod buf;
 mod common;
@@ -105,14 +105,18 @@ mod decompress;
 mod handle;
 mod image_internal;
 mod transform;
-pub use self::buf::{OwnedBuf, OutputBuf};
-pub use self::common::{PixelFormat, Subsamp, Colorspace, Result, Error};
-pub use self::compress::{Compressor, compress, compress_yuv, compress_yuv_planes, compressed_buf_len};
-pub use self::decompress::{Decompressor, DecompressHeader, ScalingFactor, decompress, read_header, decompress_to_yuv};
-pub use self::image_internal::{Image, YuvImage, YuvPlanesImage, yuv_pixels_len, yuv_plane_len};
-pub use self::transform::{Transformer, Transform, TransformOp, TransformCrop, transform};
+pub use self::buf::{OutputBuf, OwnedBuf};
+pub use self::common::{Colorspace, Error, PixelFormat, Result, Subsamp};
+pub use self::compress::{
+    compress, compress_yuv, compress_yuv_planes, compressed_buf_len, Compressor,
+};
+pub use self::decompress::{
+    decompress, decompress_to_yuv, read_header, DecompressHeader, Decompressor, ScalingFactor,
+};
+pub use self::image_internal::{yuv_pixels_len, yuv_plane_len, Image, YuvImage, YuvPlanesImage};
+pub use self::transform::{transform, Transform, TransformCrop, TransformOp, Transformer};
 
 #[cfg(feature = "image")]
 mod image_rs;
 #[cfg(feature = "image")]
-pub use self::image_rs::{JpegPixel, compress_image, decompress_image};
+pub use self::image_rs::{compress_image, decompress_image, JpegPixel};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,22 +3,22 @@
 //! - [Compression][compress()]: encode images into JPEG.
 //! - [Decompression][decompress()]: decode JPEGs into pixels.
 //! - [Lossless transformations][transform()]: apply basic geometric transformations (rotate, mirror,
-//! ...) without going through decompression and compression, so that the image does not lose
-//! quality.
+//!   ...) without going through decompression and compression, so that the image does not lose
+//!   quality.
 //! - [Compression from YUV][compress_yuv()]: encode JPEG from YUV, both in pixel format and in
-//! [planar format][compress_yuv_planes()].
+//!   [planar format][compress_yuv_planes()].
 //! - [Decompression into YUV][decompress_to_yuv()]: decode JPEG into YUV (YCbCr), without
-//! performing the color transform into RGB.
+//!   performing the color transform into RGB.
 //! - [Fractional scaling during decompression][Decompressor::set_scaling_factor()]: save time and
-//! memory by downscaling or upscaling the JPEG image while decoding.
+//!   memory by downscaling or upscaling the JPEG image while decoding.
 //!
 //! # Integration with image-rs (version 0.24)
-//! 
+//!
 //! To easily encode and decode images from the [`image`][image-rs] crate (version 0.24), please
 //! enable the optional dependency `"image"` of this crate in your `Cargo.toml`. Then you can use
 //! the functions [`decompress_image()`][crate::decompress_image] and
 //! [`compress_image()`][crate::compress_image]:
-//! 
+//!
 //! ```
 //! # #[cfg(feature = "image")] {
 //! // read JPEG data from file
@@ -33,14 +33,14 @@
 //! # }
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
-//! 
+//!
 //! This crate supports these specializations of [`image::ImageBuffer`]:
-//! 
+//!
 //! - [`image::RgbImage`]
 //! - [`image::RgbaImage`] (JPEG does not support alpha channel, so alpha is ignored when encoding
-//! and set to 255 when decoding)
+//!   and set to 255 when decoding)
 //! - [`image::GrayImage`]
-//! 
+//!
 //! [image-rs]: https://docs.rs/image/*/image/index.html
 //!
 //! # The [`Image`] type
@@ -58,27 +58,27 @@
 //! - **Decompress** images from JPEG using [`decompress()`] or [`Decompressor`].
 //! - **Compress** images into JPEG using [`compress()`] or [`Compressor`].
 //! - **Transform** images without recompression using [`transform()`] or [`Transformer`]. The
-//! transformations are described in the [`Transform`] struct.
+//!   transformations are described in the [`Transform`] struct.
 //! - **Read header** of JPEG image to get its size without decompression using
-//! [`Decompressor::read_header()`] or [`read_header()`].
+//!   [`Decompressor::read_header()`] or [`read_header()`].
 //! - **Decompress** images **into YUV** using [`decompress_to_yuv()`] or [`Decompressor`].
 //! - **Compress** images **from YUV** using [`compress_yuv()`] or [`Compressor`].
-//! 
+//!
 //! # The [`OutputBuf`] and [`OwnedBuf`] types
 //!
 //! During compression, we need to write the produced JPEG data into some memory buffer. You have
 //! two options:
 //!
 //! - Write the data into a mutable slice (`&mut [u8]`) that you already allocated and initialized.
-//! This has the disadvantage that you must allocate all memory up front, so you need to make the
-//! buffer very large to ensure that it can hold the compressed image even in the worst case, when
-//! the compression does not reduce the image size at all. You will also need to initialize the
-//! memory to comply with the Rust safety requirements.
+//!   This has the disadvantage that you must allocate all memory up front, so you need to make the
+//!   buffer very large to ensure that it can hold the compressed image even in the worst case, when
+//!   the compression does not reduce the image size at all. You will also need to initialize the
+//!   memory to comply with the Rust safety requirements.
 //!
 //! - Write the data into a memory buffer managed by TurboJPEG. This has the advantage that
-//! TurboJPEG can automatically resize the buffer, so we don't have to conservatively allocate and
-//! initialize a large chunk of memory, but we can let TurboJPEG grow the buffer as needed. This
-//! kind of buffer is exposed as the [`OwnedBuf`].
+//!   TurboJPEG can automatically resize the buffer, so we don't have to conservatively allocate and
+//!   initialize a large chunk of memory, but we can let TurboJPEG grow the buffer as needed. This
+//!   kind of buffer is exposed as the [`OwnedBuf`].
 //!
 //! To handle both of these cases, this crate provides the [`OutputBuf`] type, which can hold
 //! either a `&mut [u8]` or an `OwnedBuf`.

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -126,12 +126,13 @@ impl Transform {
 }
 
 /// Transform operation.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[doc(alias = "TJXOP")]
 #[repr(u32)]
 #[non_exhaustive]
 pub enum TransformOp {
     /// No transformation (noop).
+    #[default]
     #[doc(alias = "TJXOP_NONE")]
     None = raw::TJXOP_TJXOP_NONE,
 
@@ -183,12 +184,6 @@ pub enum TransformOp {
     Rot270 = raw::TJXOP_TJXOP_ROT270,
 }
 
-impl Default for TransformOp {
-    fn default() -> Self {
-        TransformOp::None
-    }
-}
-
 /// Transform cropping region.
 ///
 /// The [`x`][Self::x] and [`y`][Self::y] position of the region must be aligned on MCU boundaries.
@@ -234,7 +229,7 @@ impl Transformer {
     /// // initialize the transformer
     /// let mut transformer = turbojpeg::Transformer::new()?;
     ///
-    /// // define the transformation: flip vertically, trim partial MCU blocks on the bottom edge 
+    /// // define the transformation: flip vertically, trim partial MCU blocks on the bottom edge
     /// let mut transform = turbojpeg::Transform::op(turbojpeg::TransformOp::Vflip);
     /// transform.trim = true;
     ///

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,8 +1,8 @@
-use std::ptr;
-use std::convert::TryInto as _;
-use crate::buf::{OwnedBuf, OutputBuf};
+use crate::buf::{OutputBuf, OwnedBuf};
 use crate::common::{Error, Result};
 use crate::handle::Handle;
+use std::convert::TryInto as _;
+use std::ptr;
 
 /// Transforms JPEG images without recompression.
 ///
@@ -121,7 +121,10 @@ impl Transform {
     /// transform.progressive = true;
     /// ```
     pub fn op(op: TransformOp) -> Transform {
-        Transform { op, ..Transform::default() }
+        Transform {
+            op,
+            ..Transform::default()
+        }
     }
 }
 
@@ -252,25 +255,49 @@ impl Transformer {
         output: &mut OutputBuf,
     ) -> Result<()> {
         let mut options = 0;
-        if transform.perfect { options |= raw::TJXOPT_PERFECT }
-        if transform.trim { options |= raw::TJXOPT_TRIM }
-        if transform.gray { options |= raw::TJXOPT_GRAY }
-        if transform.progressive { options |= raw::TJXOPT_PROGRESSIVE }
-        if transform.optimize { options |= raw::TJXOPT_OPTIMIZE }
-        if transform.copy_none { options |= raw::TJXOPT_COPYNONE }
+        if transform.perfect {
+            options |= raw::TJXOPT_PERFECT
+        }
+        if transform.trim {
+            options |= raw::TJXOPT_TRIM
+        }
+        if transform.gray {
+            options |= raw::TJXOPT_GRAY
+        }
+        if transform.progressive {
+            options |= raw::TJXOPT_PROGRESSIVE
+        }
+        if transform.optimize {
+            options |= raw::TJXOPT_OPTIMIZE
+        }
+        if transform.copy_none {
+            options |= raw::TJXOPT_COPYNONE
+        }
 
         let mut region = raw::tjregion {
-            x: 0, y: 0,
-            w: 0, h: 0,
+            x: 0,
+            y: 0,
+            w: 0,
+            h: 0,
         };
         if let Some(crop) = transform.crop {
-            region.x = crop.x.try_into().map_err(|_| Error::IntegerOverflow("crop.x"))?;
-            region.y = crop.y.try_into().map_err(|_| Error::IntegerOverflow("crop.y"))?;
+            region.x = crop
+                .x
+                .try_into()
+                .map_err(|_| Error::IntegerOverflow("crop.x"))?;
+            region.y = crop
+                .y
+                .try_into()
+                .map_err(|_| Error::IntegerOverflow("crop.y"))?;
             if let Some(crop_w) = crop.width {
-                region.w = crop_w.try_into().map_err(|_| Error::IntegerOverflow("crop.width"))?;
+                region.w = crop_w
+                    .try_into()
+                    .map_err(|_| Error::IntegerOverflow("crop.width"))?;
             }
             if let Some(crop_h) = crop.height {
-                region.h = crop_h.try_into().map_err(|_| Error::IntegerOverflow("crop.height"))?;
+                region.h = crop_h
+                    .try_into()
+                    .map_err(|_| Error::IntegerOverflow("crop.height"))?;
             }
             options |= raw::TJXOPT_CROP;
         }
@@ -291,17 +318,20 @@ impl Transformer {
         let res = unsafe {
             raw::tj3Transform(
                 self.handle.as_ptr(),
-                jpeg_data.as_ptr(), jpeg_data.len() as raw::size_t,
-                1, &mut output.ptr, &mut output_len,
+                jpeg_data.as_ptr(),
+                jpeg_data.len() as raw::size_t,
+                1,
+                &mut output.ptr,
+                &mut output_len,
                 &transform,
             )
         };
         output.len = output_len as usize;
         if res != 0 {
-            return Err(self.handle.get_error())
+            return Err(self.handle.get_error());
         } else if output.ptr.is_null() {
             output.len = 0;
-            return Err(Error::Null)
+            return Err(Error::Null);
         }
 
         Ok(())
@@ -310,7 +340,11 @@ impl Transformer {
     /// Transforms the `image` into an owned buffer.
     ///
     /// This method automatically allocates the memory and avoids needless copying.
-    pub fn transform_to_owned(&mut self, transform: &Transform, jpeg_data: &[u8]) -> Result<OwnedBuf> {
+    pub fn transform_to_owned(
+        &mut self,
+        transform: &Transform,
+        jpeg_data: &[u8],
+    ) -> Result<OwnedBuf> {
         let mut buf = OutputBuf::new_owned();
         self.transform(transform, jpeg_data, &mut buf)?;
         Ok(buf.into_owned())
@@ -346,7 +380,6 @@ impl Transformer {
         self.transform(transform, jpeg_data, &mut buf)?;
         Ok(buf.len())
     }
-
 }
 
 /// Losslessly transform a JPEG image without recompression.

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -275,7 +275,7 @@ impl Transformer {
             options |= raw::TJXOPT_CROP;
         }
 
-        let mut transform = raw::tjtransform {
+        let transform = raw::tjtransform {
             r: region,
             op: transform.op as libc::c_int,
             options: options as libc::c_int,
@@ -293,7 +293,7 @@ impl Transformer {
                 self.handle.as_ptr(),
                 jpeg_data.as_ptr(), jpeg_data.len() as raw::size_t,
                 1, &mut output.ptr, &mut output_len,
-                &mut transform,
+                &transform,
             )
         };
         output.len = output_len as usize;


### PR DESCRIPTION
Main purpose: add configuration for runnings tests and lints on CI

Minor changes to appease linter:

- Indent some lines in markdown lists
- Derive Default where possible
- Impl Default where existing new() method is cheap
- Add is_empty() where len() exists and it makes sense

Possibly functional change:

- https://github.com/honzasp/rust-turbojpeg/pull/39/changes/0e022630a3b09f9f3cfa6a75c8a2d9a0f5ca1545 - the linter suggests that the `transform` variable does not need to be mutable. Tests pass when it is immutable. If mutation may actually happen and it's labelled as `mut` on the rust side to be clear, I can revert that commit and would just add some docs and/or a clippy exemption.